### PR TITLE
feat: CustomTable에 progress 타입 추가 및 스크롤 레이아웃 수정(#9)

### DIFF
--- a/src/components/CustomTable/CustomTable.jsx
+++ b/src/components/CustomTable/CustomTable.jsx
@@ -20,6 +20,7 @@ import {
   FormControl,
   InputLabel,
   TableSortLabel,
+  LinearProgress,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 
@@ -146,11 +147,11 @@ export default function CustomTable({
       )}
 
       {/* 가로 스크롤 영역 */}
-      <Box sx={{ overflowX: "auto", flex: 1 }}>
+      <Box sx={{ flex: 1, overflow: "auto" }}>
         <Box
           sx={{
             height: "100%",
-            overflowY: "auto",
+            overflow: "auto",
             "&::-webkit-scrollbar": { width: 6 },
             "&::-webkit-scrollbar-thumb": {
               backgroundColor: theme.palette.grey[300],
@@ -186,7 +187,6 @@ export default function CustomTable({
                         }
                         onClick={() => handleSort(col.key)}
                         hideSortIcon={false}
-                        g
                         sx={{
                           "& .MuiTableSortLabel-icon": {
                             opacity: 1,
@@ -344,6 +344,27 @@ function renderCellContent(col, value, row, theme) {
           {action.label}
         </Button>
       ));
+
+    case "progress":
+      return (
+        <Box display="flex" alignItems="center" gap={1}>
+          <Box flexGrow={1}>
+            <LinearProgress
+              variant="determinate"
+              value={value ?? 0}
+              sx={{
+                height: 8,
+                borderRadius: 4,
+                backgroundColor: (theme) => theme.palette.grey[200],
+                "& .MuiLinearProgress-bar": {
+                  backgroundColor: (theme) => theme.palette.primary.main,
+                },
+              }}
+            />
+          </Box>
+          <Typography variant="caption">{value ?? 0}%</Typography>
+        </Box>
+      );
 
     case "custom":
       return col.render ? col.render(value, row) : value;

--- a/src/layouts/MainLayout.styles.js
+++ b/src/layouts/MainLayout.styles.js
@@ -9,6 +9,7 @@ export const Root = styled(Box)(({ theme }) => ({
   height: "100vh",
   backgroundColor: theme.palette.text.primary,
   position: "relative",
+  overflow: "hidden",
 }));
 
 export const MobileToggleButton = styled(IconButton)(({ theme }) => ({
@@ -38,5 +39,5 @@ export const Main = styled(Box)(({ theme }) => ({
   margin: theme.spacing(1),
   padding: theme.spacing(1),
   backgroundColor: theme.palette.primary,
-  overflowY: "auto",
+  overflow: "hidden",
 }));


### PR DESCRIPTION
## 📌 개요

- CustomTable 컴포넌트에 진행도 (Progress Bar) 타입을 추가하고
- 가로/세로 스크롤이 깔끔하게 동작하도록 레이아웃 전반 수정

## 🛠️ 변경 사항

- 'progress' 타입 컬럼 추가 및 LinearProgress UI 구현
- Paper -> Box 구조로 overflow 조절
- 'height', 'overflow', 'flexGrow' 등 레이아웃 스타일링 개선
- 불필요한 외부 스크롤 제거

## ✅ 주요 체크 포인트

- [ ] 진행도 값이 0~100 사이에서 정상 렌더링되는가?
- [ ] 스크롤이 오직 테이블 내부에서만 발생하는가?
- [ ] 화면 사이즈 변화에 따라 레이아웃이 깨지지 않는가?

## 🔁 테스트 결과

- 브라우저 화면 축소/확대, 아이템 100개 이상 입력
- 진행도 0%, 50%, 100% 테스트 완료

## 🔗 연관된 이슈

- `- #9 ` - CustomTable 공통 컴포넌트 개발 및 기능 고도화

## 📑 레퍼런스

- [MUI Table Layout Best Practices] (http://mui.com/material-ui/react-table/)
