### PR TITLE
feat: PageWrapper 및 PageHeader 공통 레이아웃 컴포넌트 구현 (#15)

### DIFF
--- a/src/components/layouts/pageHeader/PageHeader.jsx
+++ b/src/components/layouts/pageHeader/PageHeader.jsx
@@ -1,0 +1,25 @@
+import { Box, Typography, Button } from "@mui/material";
+
+export default function PageHeader({ title, subtitle, action }) {
+  return (
+    <Box
+      display="flex"
+      justifyContent="space-between"
+      alignItems="center"
+      px={3}
+      py={3}
+    >
+      <Box>
+        <Typography variant="h3" fontWeight={600}>
+          {title}
+        </Typography>
+        {subtitle && (
+          <Typography variant="body2" color="text.secondary" mt={0.5}>
+            {subtitle}
+          </Typography>
+        )}
+      </Box>
+      {action}
+    </Box>
+  );
+}

--- a/src/components/layouts/pageWrapper/PageWrapper.jsx
+++ b/src/components/layouts/pageWrapper/PageWrapper.jsx
@@ -1,0 +1,19 @@
+import { Paper } from "@mui/material";
+
+export default function PageWrapper({ children }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        bgcolor: "background.default",
+        borderRadius: 4,
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}


### PR DESCRIPTION
## 📌 개요

- 전체 페이지 레이아웃 구조에 사용할 PageWrapper, 상단 타이틀/버튼을 포함하는 PageHeader 공통 컴포넌트 추가했습니다.

## 🛠️ 변경 사항

- components/layouts/pageWrapper/PageWrapper.jsx 생성 및 스타일링components/layouts/pageHeader/PageHeader.jsx 생성
- 재사용성을 고려해 props로 타이틀, 서브타이틀, 우측 액션 버튼 영역 처리
- 페이지마다 Box나 Paper로 직접 구성하던 레이아웃 제거 예정


## ✅ 주요 체크 포인트

- PageHeader에 title, subtitle, action 잘 전달되는지
- PageWrapper의 height/overflow/배경 설정이 다른 페이지에도 적용 가능한지


## 🔁 테스트 결과

- 프로젝트 페이지, 상세 페이지에 적용해 확인 완료
- 모바일, 데스크탑 화면에서 UI 깨짐 없이 동작


## 🔗 연관된 이슈

- #15 

## 📑 레퍼런스

- 없음
