### PR TITLE
[feat]프로젝트 단계 DnD 및 참여자 관리 컴포넌트 추가

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const api = axios.create({
-  baseURL: "http://localhost:4000",
+  baseURL: "http://localhost:8080",
   headers: {
     "Content-Type": "application/json",
   },

--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -1,0 +1,5 @@
+import api from "./api";
+
+export const login = (data) => api.post("api/login", data, {withCredentials: true});
+export const reissueToken = () => api.post("/api/reissue");
+export const logout = () => api.post("/api/logout");

--- a/src/components/common/sectionTable/SectionTable.jsx
+++ b/src/components/common/sectionTable/SectionTable.jsx
@@ -1,5 +1,5 @@
 // src/components/common/sectionTable/SectionTable.jsx
-import React from "react";
+import React, { useState, useMemo } from "react";
 import {
   Table,
   TableBody,
@@ -8,18 +8,20 @@ import {
   TableHead,
   TableRow,
   Stack,
+  TableSortLabel,
 } from "@mui/material";
 import CustomButton from "@/components/common/customButton/CustomButton";
 
 /**
- * SectionTable 컴포넌트
- * @param {Array} columns - 컬럼 정의 [{ key, label, renderCell?, width? }]
- * @param {Array} rows - 데이터 배열
- * @param {string} rowKey - 각 행의 고유키 (default: 'id')
- * @param {object} containerSx - TableContainer sx
- * @param {Array<string>} phases - 단계 버튼에 표시할 탭 목록 (optional)
- * @param {string} selectedPhase - 현재 선택된 단계
- * @param {function} onPhaseChange - 단계 변경 시 호출할 콜백
+ * SectionTable 컴포넌트 (정렬 기능 추가)
+ *
+ * props:
+ * - columns: [{ key, label, renderCell?, width?, sortable? }]  // sortable 플래그 추가
+ * - rows: 데이터 배열
+ * - rowKey: 각 행의 고유키 (default: 'id')
+ * - phases: 단계 버튼에 표시할 탭 목록 (optional)
+ * - selectedPhase: 현재 선택된 단계 (optional)
+ * - onPhaseChange: 단계 변경 시 호출할 콜백 (optional)
  */
 export default function SectionTable({
   columns,
@@ -29,6 +31,52 @@ export default function SectionTable({
   selectedPhase,
   onPhaseChange,
 }) {
+  // 정렬 상태 관리
+  const [sortConfig, setSortConfig] = useState({ key: null, direction: "asc" });
+
+  // 헤더 클릭 시 호출되는 정렬 핸들러
+  const handleSort = (columnKey) => {
+    setSortConfig((prev) => {
+      if (prev.key === columnKey) {
+        // 같은 컬럼을 다시 클릭하면 asc↔desc 토글
+        return {
+          key: columnKey,
+          direction: prev.direction === "asc" ? "desc" : "asc",
+        };
+      } else {
+        // 다른 컬럼 클릭 시 기본 asc
+        return { key: columnKey, direction: "asc" };
+      }
+    });
+  };
+
+  // 정렬된 행 배열을 메모이제이션
+  const sortedRows = useMemo(() => {
+    if (!sortConfig.key) {
+      return rows;
+    }
+    // 단순 비교 정렬 (숫자 or 문자열)
+    return [...rows].sort((a, b) => {
+      const aVal = a[sortConfig.key];
+      const bVal = b[sortConfig.key];
+
+      // undefined/null 처리
+      if (aVal == null && bVal == null) return 0;
+      if (aVal == null) return sortConfig.direction === "asc" ? -1 : 1;
+      if (bVal == null) return sortConfig.direction === "asc" ? 1 : -1;
+
+      // 숫자와 문자를 구분하여 비교
+      if (typeof aVal === "number" && typeof bVal === "number") {
+        return sortConfig.direction === "asc" ? aVal - bVal : bVal - aVal;
+      }
+      const aStr = aVal.toString();
+      const bStr = bVal.toString();
+      if (aStr < bStr) return sortConfig.direction === "asc" ? -1 : 1;
+      if (aStr > bStr) return sortConfig.direction === "asc" ? 1 : -1;
+      return 0;
+    });
+  }, [rows, sortConfig]);
+
   return (
     <>
       {/* phases 옵션이 있으면 상단 필터 버튼 렌더링 */}
@@ -58,15 +106,38 @@ export default function SectionTable({
               {columns.map((col) => (
                 <TableCell
                   key={col.key}
-                  sx={{ fontWeight: 600, width: col.width }}
+                  sx={{
+                    fontWeight: 600,
+                    width: col.width,
+                    whiteSpace: "nowrap",
+                  }}
+                  sortDirection={
+                    sortConfig.key === col.key ? sortConfig.direction : false
+                  }
                 >
-                  {col.label}
+                  {col.sortable ? (
+                    <TableSortLabel
+                      active={sortConfig.key === col.key}
+                      direction={
+                        sortConfig.key === col.key
+                          ? sortConfig.direction
+                          : "asc"
+                      }
+                      onClick={() => handleSort(col.key)}
+                      hideSortIcon={false}
+                    >
+                      {col.label}
+                    </TableSortLabel>
+                  ) : (
+                    col.label
+                  )}
                 </TableCell>
               ))}
             </TableRow>
           </TableHead>
+
           <TableBody>
-            {rows.map((row) => (
+            {sortedRows.map((row) => (
               <TableRow key={row[rowKey]} hover>
                 {columns.map((col) => (
                   <TableCell key={col.key}>

--- a/src/components/layouts/tabsWithContent/TabsWithContent.jsx
+++ b/src/components/layouts/tabsWithContent/TabsWithContent.jsx
@@ -31,7 +31,7 @@ export default function TabsWithContent({
         value={value}
         onChange={onChange}
         sx={{
-          minHeight: 48,
+          minHeight: 30,
           borderBottom: "1px solid",
           borderColor: "divider",
           "& .MuiTabs-indicator": {

--- a/src/features/auth/api.js
+++ b/src/features/auth/api.js
@@ -1,1 +1,0 @@
-// auth API module

--- a/src/features/auth/authSlice.js
+++ b/src/features/auth/authSlice.js
@@ -1,1 +1,98 @@
-// auth Redux slice
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import * as authAPI from "@/api/auth";
+
+export const login = createAsyncThunk("auth/login", async (credentials, thunkAPI) => {
+  try {
+    const response = await authAPI.login(credentials);
+    return response.data;
+  } catch (error) {
+    console.log('error', error)
+    return thunkAPI.rejectWithValue(error.response?.data || "Login failed");
+  }
+});
+
+export const reissueToken = createAsyncThunk("auth/reissueToken", async (_, thunkAPI) => {
+  try {
+    const response = await authAPI.reissueToken();
+    return response.data;
+  } catch (error) {
+    return thunkAPI.rejectWithValue(error.response?.data || "Reissue failed");
+  }
+});
+
+export const logout = createAsyncThunk("auth/logout", async (_, thunkAPI) => {
+  try {
+    await authAPI.logout();
+    return true;
+  } catch (error) {
+    return thunkAPI.rejectWithValue(error.response?.data || "Logout failed");
+  }
+});
+
+const authSlice = createSlice({
+  name: "auth",
+  initialState: {
+    user: null,
+    accessToken: null,
+    status: "idle",
+    error: null,
+  },
+  reducers: {
+    clearAuthState(state) {
+      state.user = null;
+      state.accessToken = null;
+      state.status = "idle";
+      state.error = null;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+
+      // === LOGIN ===
+      .addCase(login.pending, (state) => {
+        state.status = "loading";
+        state.error = null;
+      })
+      .addCase(login.fulfilled, (state, action) => {
+        state.status = "succeeded";
+        state.user = action.payload.user;
+        state.accessToken = action.payload.accessToken;
+      })
+      .addCase(login.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload;
+      })
+
+      // === REISSUE TOKEN ===
+      .addCase(reissueToken.pending, (state) => {
+        state.status = "loading";
+        state.error = null;
+      })
+      .addCase(reissueToken.fulfilled, (state, action) => {
+        state.accessToken = action.payload.accessToken;
+        state.status = "succeeded";
+      })
+      .addCase(reissueToken.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload;
+      })
+
+      // === LOGOUT ===
+      .addCase(logout.pending, (state) => {
+        state.status = "loading";
+        state.error = null;
+      })
+      .addCase(logout.fulfilled, (state) => {
+        state.status = "idle";
+        state.user = null;
+        state.accessToken = null;
+      })
+      .addCase(logout.rejected, (state, action) => {
+        state.status = "failed";
+        state.error = action.payload;
+      });
+  },
+});
+
+export const { clearAuthState } = authSlice.actions;
+export default authSlice.reducer;

--- a/src/features/auth/pages/LoginPage.jsx
+++ b/src/features/auth/pages/LoginPage.jsx
@@ -1,0 +1,109 @@
+import React, { useState } from "react";
+import {
+  Box,
+  TextField,
+  Typography,
+  Paper,
+  Stack,
+  Link,
+} from "@mui/material";
+import { useDispatch, useSelector } from "react-redux";
+import { useNavigate } from "react-router-dom";
+import {
+  RootBox,
+  LoginPaper,
+  LoginButton,
+} from "./LoginPage.styles";
+import { login } from "@/features/auth/authSlice";
+
+export default function LoginPage() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { loading, error } = useSelector((state) => state.auth);
+
+  const [form, setForm] = useState({
+    email: "",
+    password: "",
+  });
+
+  const handleChange = (e) => {
+    setForm((prev) => ({
+      ...prev,
+      [e.target.name]: e.target.value,
+    }));
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+
+    const result = await dispatch(login(form));
+    if (login.fulfilled.match(result)) {
+      navigate("/"); // 로그인 성공 시 홈으로 이동
+    } else {
+      console.log('result: ', result)
+      console.error("로그인 실패:", result.payload || result.error);
+    }
+  };
+
+  return (
+    <RootBox>
+      <LoginPaper elevation={3}>
+        <Typography variant="h6" gutterBottom textAlign="center" fontWeight="bold">
+          MyWork
+        </Typography>
+
+        <Typography variant="h5" gutterBottom textAlign="center" fontWeight={600}>
+          로그인
+        </Typography>
+
+        <form onSubmit={handleSubmit}>
+          <Stack spacing={2}>
+            <TextField
+              label="아이디"
+              name="email"
+              value={form.email}
+              onChange={handleChange}
+              fullWidth
+              required
+            />
+            <TextField
+              label="비밀번호"
+              name="password"
+              type="password"
+              value={form.password}
+              onChange={handleChange}
+              fullWidth
+              required
+            />
+
+            {error && (
+              <Typography variant="body2" color="error">
+                {typeof error === "string" ? error : "로그인에 실패했습니다"}
+              </Typography>
+            )}
+
+            <Box textAlign="right">
+              <Link
+                href="#"
+                variant="body2"
+                underline="hover"
+                color="text.secondary"
+              >
+                비밀번호를 잊으셨나요?
+              </Link>
+            </Box>
+
+            <LoginButton
+              type="submit"
+              variant="contained"
+              fullWidth
+              disabled={loading}
+            >
+              {loading ? "로그인 중..." : "로그인"}
+            </LoginButton>
+          </Stack>
+        </form>
+      </LoginPaper>
+    </RootBox>
+  );
+}

--- a/src/features/auth/pages/LoginPage.styles.js
+++ b/src/features/auth/pages/LoginPage.styles.js
@@ -1,0 +1,28 @@
+import { styled } from "@mui/material/styles";
+import Box from "@mui/material/Box";
+import Paper from "@mui/material/Paper";
+import Button from "@mui/material/Button";
+
+export const RootBox = styled(Box)(({ theme }) => ({
+  height: "100vh",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  backgroundColor: theme.palette.text.primary,
+}));
+
+export const LoginPaper = styled(Paper)(({ theme }) => ({
+  padding: theme.spacing(4),
+  width: 360,
+  borderRadius: 12,
+  backgroundColor: theme.palette.background.paper,
+}));
+
+export const LoginButton = styled(Button)(({ theme }) => ({
+  marginTop: theme.spacing(1),
+  backgroundColor: theme.palette.primary.main,
+  color: theme.palette.primary.contrastText,
+  "&:hover": {
+    backgroundColor: theme.palette.grey[700],
+  },
+}));

--- a/src/features/project/components/PostTable.jsx
+++ b/src/features/project/components/PostTable.jsx
@@ -1,10 +1,10 @@
 // src/components/common/postTable/PostTable.jsx
-import React, { useState } from "react";
-import { LinearProgress, Stack, Typography, Avatar } from "@mui/material";
+import React, { useState, useMemo } from "react";
+import { LinearProgress, Stack, Typography, Chip } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import SectionTable from "@/components/common/sectionTable/SectionTable";
 
-// 샘플 데이터, 필요시 rows prop으로 오버라이드 가능합니다.
+// 샘플 데이터
 const defaultRows = [
   {
     id: 1,
@@ -33,47 +33,64 @@ export default function PostTable({ rows }) {
   const phaseTabs = ["전체", "기획", "디자인", "퍼블리싱", "개발", "검수"];
   const [selectedPhase, setSelectedPhase] = useState(phaseTabs[0]);
 
+  // 실제 사용할 데이터
   const dataRows = rows && rows.length ? rows : defaultRows;
-  const filteredRows =
-    selectedPhase === phaseTabs[0]
-      ? dataRows
-      : dataRows.filter((row) => row.status === selectedPhase);
 
+  // 단계별 필터링
+  const filteredRows = useMemo(() => {
+    if (selectedPhase === phaseTabs[0]) return dataRows;
+    return dataRows.filter((row) => row.status === selectedPhase);
+  }, [dataRows, selectedPhase]);
+
+  // "상태" 칩 렌더링 함수: theme.palette.status 구조 활용
   const getStatusChip = (status) => {
-    const statusMap = {
-      기획: theme.palette.status.warning,
-      디자인: theme.palette.status.success,
-      퍼블리싱: theme.palette.status.info,
-      개발: theme.palette.status.primary,
-      검수: theme.palette.status.error,
+    const map = {
+      기획: "warning",
+      디자인: "info",
+      퍼블리싱: "success",
+      개발: "primary",
+      검수: "error",
     };
-    const color = statusMap[status] || theme.palette.grey;
+
+    const statusKey = map[status];
+    const statusObj =
+      theme.palette.status[statusKey] ?? theme.palette.status.neutral;
+
     return (
-      <Avatar
-        variant="rounded"
+      <Chip
+        label={status}
+        size="small"
         sx={{
-          bgcolor: color.light,
-          color: color.main,
-          fontSize: 12,
-          px: 1,
+          backgroundColor: statusObj.bg,
+          color: statusObj.main,
+          borderRadius: "12px",
+          fontWeight: 500,
+          fontSize: 13,
         }}
-      >
-        {status}
-      </Avatar>
+      />
     );
   };
 
+  // 컬럼 정의: sortable을 true로 설정하면 헤더 클릭 시 정렬 가능
   const columns = [
-    { key: "title", label: "제목" },
+    {
+      key: "title",
+      label: "제목",
+      width: 200,
+      sortable: true,
+    },
     {
       key: "status",
       label: "상태",
-      renderCell: (row) => getStatusChip(row.status),
       width: 120,
+      sortable: true,
+      renderCell: (row) => getStatusChip(row.status),
     },
     {
       key: "progress",
       label: "진행도",
+      width: 140,
+      sortable: true,
       renderCell: (row) => (
         <Stack spacing={0.5}>
           <LinearProgress
@@ -96,21 +113,30 @@ export default function PostTable({ rows }) {
           </Typography>
         </Stack>
       ),
-      width: 140,
     },
-    { key: "dueDate", label: "마감일", width: 110 },
+    {
+      key: "dueDate",
+      label: "마감일",
+      width: 110,
+      sortable: true,
+    },
     {
       key: "assignee",
       label: "담당자",
+      width: 140,
+      sortable: true,
       renderCell: (row) => (
         <Stack direction="row" spacing={1} alignItems="center">
-          <Avatar src={row.assignee.avatar} sx={{ width: 24, height: 24 }} />
+          <img
+            src={row.assignee.avatar}
+            alt={row.assignee.name}
+            style={{ width: 24, height: 24, borderRadius: "50%" }}
+          />
           <Typography variant="body2" fontWeight={500}>
             {row.assignee.name}
           </Typography>
         </Stack>
       ),
-      width: 140,
     },
   ];
 
@@ -121,6 +147,7 @@ export default function PostTable({ rows }) {
       phases={phaseTabs}
       selectedPhase={selectedPhase}
       onPhaseChange={setSelectedPhase}
+      rowKey="id"
     />
   );
 }

--- a/src/features/project/components/ProjectForm.jsx
+++ b/src/features/project/components/ProjectForm.jsx
@@ -1,0 +1,168 @@
+// src/features/project/components/ProjectForm.jsx
+import React from "react";
+import {
+  TextField,
+  MenuItem,
+  Paper,
+  Stack,
+  Box,
+  Typography,
+  Divider,
+  Grid,
+  Tooltip,
+} from "@mui/material";
+import { InfoOutlined } from "@mui/icons-material";
+
+/**
+ * ProjectForm 컴포넌트 (셀렉트 박스를 더 길게 설정)
+ *
+ * props:
+ * - form: { title, startDate, endDate, customerId, developerId }
+ * - handleChange: (key: string) => (e: React.ChangeEvent<HTMLInputElement>) => void
+ * - customers: 고객사 목록 (배열 [{ id, name }])
+ * - companies: 개발사 목록 (배열 [{ id, name }])
+ * - isEdit: 편집 모드인지 여부 (boolean)
+ */
+export default function ProjectForm({
+  form,
+  handleChange,
+  customers = [],
+  companies = [],
+  isEdit = false,
+}) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", flex: 1 }}>
+      <Paper
+        sx={{
+          p: 4,
+          mb: 3,
+          mx: 3,
+          borderRadius: 2,
+          boxShadow: 2,
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          boxSizing: "border-box",
+        }}
+      >
+        {/* 폼 입력 영역 */}
+        <Stack spacing={4} sx={{ flex: 1 }}>
+          {/* 1) 기본 정보 섹션 */}
+          <Box>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                1. 기본 정보
+              </Typography>
+              <Tooltip title="프로젝트 이름은 필수 입력 항목입니다.">
+                <InfoOutlined fontSize="small" color="action" />
+              </Tooltip>
+            </Stack>
+            <Divider sx={{ mt: 1, mb: 2 }} />
+
+            <TextField
+              required
+              label="프로젝트 이름"
+              placeholder="예) AI 챗봇 개발 프로젝트"
+              helperText={form.title ? "" : "프로젝트 이름을 입력해주세요."}
+              error={!form.title}
+              value={form.title || ""}
+              onChange={handleChange("title")}
+              fullWidth
+            />
+          </Box>
+
+          {/* 2) 기간 설정 섹션 */}
+          <Box>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                2. 기간 설정
+              </Typography>
+              <Tooltip title="시작일과 종료일을 선택하세요.">
+                <InfoOutlined fontSize="small" color="action" />
+              </Tooltip>
+            </Stack>
+            <Divider sx={{ mt: 1, mb: 2 }} />
+
+            <Grid container spacing={3} justifyContent="flex-start">
+              <Grid item xs={12} sm={6} md={4}>
+                <TextField
+                  label="시작일"
+                  type="date"
+                  placeholder="YYYY-MM-DD"
+                  InputLabelProps={{ shrink: true }}
+                  helperText="프로젝트 시작일을 선택하세요."
+                  value={form.startDate || ""}
+                  onChange={handleChange("startDate")}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12} sm={6} md={4}>
+                <TextField
+                  label="종료일"
+                  type="date"
+                  placeholder="YYYY-MM-DD"
+                  InputLabelProps={{ shrink: true }}
+                  helperText="프로젝트 종료일을 선택하세요."
+                  value={form.endDate || ""}
+                  onChange={handleChange("endDate")}
+                  fullWidth
+                />
+              </Grid>
+            </Grid>
+          </Box>
+
+          {/* 3) 고객사/개발사 선택 섹션 */}
+          <Box>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                3. 고객사/개발사
+              </Typography>
+              <Tooltip title="고객사와 개발사를 선택하세요.">
+                <InfoOutlined fontSize="small" color="action" />
+              </Tooltip>
+            </Stack>
+            <Divider sx={{ mt: 1, mb: 2 }} />
+
+            <Grid container spacing={3} justifyContent="flex-start">
+              {/* xs=12: 모바일에서는 전체 너비, sm 이상에서는 자동으로 6/12(50%) */}
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  select
+                  label="고객사"
+                  value={form.customerId || ""}
+                  onChange={handleChange("customerId")}
+                  helperText="고객사를 선택하세요."
+                  // 아래 sx를 통해 sm 이상에서 300px 고정, xs에서는 100% 너비
+                  sx={{ width: { xs: "100%", sm: 300 } }}
+                >
+                  {customers.map((cust) => (
+                    <MenuItem key={cust.id} value={cust.id}>
+                      {cust.name}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  select
+                  label="개발사"
+                  value={form.developerId || ""}
+                  onChange={handleChange("developerId")}
+                  helperText="개발사를 선택하세요."
+                  sx={{ width: { xs: "100%", sm: 300 } }}
+                >
+                  {companies.map((comp) => (
+                    <MenuItem key={comp.id} value={comp.id}>
+                      {comp.name}
+                    </MenuItem>
+                  ))}
+                </TextField>
+              </Grid>
+            </Grid>
+          </Box>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+}

--- a/src/features/project/components/ProjectManagement.jsx
+++ b/src/features/project/components/ProjectManagement.jsx
@@ -1,0 +1,276 @@
+// src/features/project/components/ProjectManagement.jsx
+import React, { useState } from "react";
+import {
+  Box,
+  Stack,
+  Card,
+  Typography,
+  IconButton,
+  TextField,
+  Button,
+  Avatar,
+  List,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  ListItemSecondaryAction,
+  Divider,
+  Paper,
+} from "@mui/material";
+import { useTheme } from "@mui/material/styles";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  horizontalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import DragIndicatorIcon from "@mui/icons-material/DragIndicator";
+import DeleteIcon from "@mui/icons-material/Delete";
+import AddIcon from "@mui/icons-material/Add";
+
+/**
+ * StageCard 컴포넌트
+ * - 카드 내부에서 useTheme()를 사용해 theme를 참조하도록 수정
+ */
+function StageCard({ id, label, index }) {
+  const theme = useTheme();
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    cursor: "grab",
+    userSelect: "none",
+  };
+
+  return (
+    <Card
+      ref={setNodeRef}
+      sx={{
+        ...style,
+        display: "flex",
+        alignItems: "center",
+        px: 2,
+        py: 1,
+        border: `1px solid ${theme.palette.divider}`,
+        boxShadow: "none",
+        minWidth: 160,
+        maxWidth: 180,
+        bgcolor: isDragging
+          ? theme.palette.background.default
+          : theme.palette.background.paper,
+        borderRadius: 2,
+        mb: 1.5,
+        mx: 1.5,
+      }}
+      {...attributes}
+      {...listeners}
+    >
+      {/* 드래그 아이콘 + 번호 + 라벨을 한 행에 */}
+      <DragIndicatorIcon
+        color={isDragging ? "primary" : "action"}
+        sx={{ mr: 1.5 }}
+      />
+      <Typography
+        variant="body1"
+        sx={{
+          fontSize: { xs: 14, sm: 15 },
+          fontWeight: 600,
+          mr: 0.5,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {index + 1}.
+      </Typography>
+      <Typography
+        variant="body1"
+        sx={{
+          fontSize: { xs: 14, sm: 15 },
+          fontWeight: 500,
+          color: theme.palette.text.primary,
+          whiteSpace: "nowrap",
+        }}
+      >
+        {label}
+      </Typography>
+    </Card>
+  );
+}
+
+/**
+ * ProjectManagement 컴포넌트
+ */
+export default function ProjectManagement({
+  initialStages = ["기획", "디자인", "퍼블리싱", "개발", "검수"],
+  initialParticipants = [
+    { id: 1, name: "이수하", avatarUrl: "/avatar1.jpg" },
+    { id: 2, name: "김철수", avatarUrl: "/avatar2.jpg" },
+  ],
+}) {
+  const theme = useTheme();
+
+  // 단계 카드 순서 관리
+  const [stages, setStages] = useState(initialStages);
+
+  // 참여자 목록 관리
+  const [participants, setParticipants] = useState(initialParticipants);
+  const [newParticipantName, setNewParticipantName] = useState("");
+
+  // DnD 센서 설정
+  const sensors = useSensors(useSensor(PointerSensor));
+
+  // 드롭 이벤트 핸들러: 순서 교체
+  const handleDragEnd = (event) => {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = stages.indexOf(active.id);
+      const newIndex = stages.indexOf(over.id);
+      setStages((prev) => arrayMove(prev, oldIndex, newIndex));
+    }
+  };
+
+  // 참여자 추가
+  const handleAddParticipant = () => {
+    const name = newParticipantName.trim();
+    if (!name) return;
+    const nextId =
+      participants.length > 0
+        ? Math.max(...participants.map((p) => p.id)) + 1
+        : 1;
+    const newParticipant = { id: nextId, name, avatarUrl: undefined };
+    setParticipants((prev) => [...prev, newParticipant]);
+    setNewParticipantName("");
+  };
+
+  // 참여자 삭제
+  const handleRemoveParticipant = (id) => {
+    setParticipants((prev) => prev.filter((p) => p.id !== id));
+  };
+
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", gap: 4, p: 2 }}>
+      {/* 1. 단계 설정 (가로 스크롤 없이, 줄바꿈) */}
+      <Box>
+        <Typography variant="h6" fontWeight={600} gutterBottom>
+          프로젝트 단계 설정
+        </Typography>
+        <Paper
+          elevation={0}
+          sx={{
+            p: 2,
+            bgcolor: theme.palette.background.paper,
+            borderRadius: 2,
+            border: `1px solid ${theme.palette.divider}`,
+          }}
+        >
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={stages}
+              strategy={horizontalListSortingStrategy}
+            >
+              <Box
+                sx={{
+                  display: "flex",
+                  flexDirection: "row",
+                  flexWrap: "wrap",
+                  justifyContent: "flex-start",
+                }}
+              >
+                {stages.map((stage, idx) => (
+                  <StageCard key={stage} id={stage} label={stage} index={idx} />
+                ))}
+              </Box>
+            </SortableContext>
+          </DndContext>
+        </Paper>
+      </Box>
+
+      {/* 2. 참여자 관리 (조회, 추가, 삭제) */}
+      <Box>
+        <Typography variant="h6" fontWeight={600} gutterBottom>
+          프로젝트 참여자 관리
+        </Typography>
+        <Stack direction="row" spacing={1} alignItems="center" sx={{ mb: 2 }}>
+          <TextField
+            size="small"
+            placeholder="이름을 입력하세요"
+            value={newParticipantName}
+            onChange={(e) => setNewParticipantName(e.target.value)}
+            sx={{ width: { xs: "100%", sm: 240 } }}
+          />
+          <Button
+            variant="contained"
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={handleAddParticipant}
+            sx={{ boxShadow: "none", textTransform: "none" }}
+          >
+            추가
+          </Button>
+        </Stack>
+        <Paper
+          elevation={0}
+          sx={{
+            border: `1px solid ${theme.palette.divider}`,
+            borderRadius: 2,
+          }}
+        >
+          <List disablePadding>
+            {participants.map((p, idx) => (
+              <React.Fragment key={p.id}>
+                <ListItem sx={{ px: 2, py: 1 }}>
+                  <ListItemAvatar>
+                    <Avatar
+                      src={p.avatarUrl}
+                      alt={p.name}
+                      sx={{ width: 32, height: 32 }}
+                    >
+                      {p.name[0]}
+                    </Avatar>
+                  </ListItemAvatar>
+                  <ListItemText
+                    primary={
+                      <Typography variant="body2" fontWeight={500}>
+                        {p.name}
+                      </Typography>
+                    }
+                  />
+                  <ListItemSecondaryAction>
+                    <IconButton
+                      edge="end"
+                      color="error"
+                      onClick={() => handleRemoveParticipant(p.id)}
+                    >
+                      <DeleteIcon />
+                    </IconButton>
+                  </ListItemSecondaryAction>
+                </ListItem>
+                {idx < participants.length - 1 && (
+                  <Divider component="li" variant="inset" />
+                )}
+              </React.Fragment>
+            ))}
+          </List>
+        </Paper>
+      </Box>
+    </Box>
+  );
+}

--- a/src/features/project/pages/ProjectDetailPage.jsx
+++ b/src/features/project/pages/ProjectDetailPage.jsx
@@ -19,6 +19,7 @@ import CreateRoundedIcon from "@mui/icons-material/CreateRounded";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import TaskIcon from "@mui/icons-material/AssignmentTurnedIn";
 import DownloadIcon from "@mui/icons-material/Download";
+import ProjectManagement from "../components/ProjectManagement";
 
 export default function ProjectDetailPage() {
   const { id } = useParams();
@@ -70,7 +71,10 @@ export default function ProjectDetailPage() {
             >
               삭제하기
             </CustomButton>
-            <CustomButton startIcon={<CreateRoundedIcon />}>
+            <CustomButton
+              startIcon={<CreateRoundedIcon />}
+              onClick={() => navigate(`/projects/${id}/edit`)}
+            >
               수정하기
             </CustomButton>
           </Stack>
@@ -108,7 +112,7 @@ export default function ProjectDetailPage() {
 
       <TabsWithContent
         tabs={[
-          { label: "단계 설정", icon: <VisibilityIcon /> },
+          { label: "프로젝트 관리", icon: <VisibilityIcon /> },
           { label: "업무 관리", icon: <TaskIcon /> },
           { label: "진척도 관리", icon: <DownloadIcon /> },
         ]}
@@ -116,7 +120,14 @@ export default function ProjectDetailPage() {
         onChange={(_, nv) => setTab(nv)}
         content={
           tab === 0 ? (
-            <Typography>단계 설정 콘텐츠</Typography>
+            <ProjectManagement
+              initialStages={["기획", "디자인", "퍼블리싱", "개발", "검수"]}
+              initialParticipants={[
+                { id: 1, name: "이수하", avatarUrl: "/avatar1.jpg" },
+
+                { id: 2, name: "김철수", avatarUrl: "/avatar2.jpg" },
+              ]}
+            />
           ) : tab === 1 ? (
             <PostTable />
           ) : (

--- a/src/features/project/projectSlice.js
+++ b/src/features/project/projectSlice.js
@@ -75,7 +75,7 @@ const projectSlice = createSlice({
   extraReducers: (builder) => {
     builder
       .addCase(fetchProjects.fulfilled, (state, action) => {
-        state.data = action.payload;
+        state.list = action.payload;
       })
       .addCase(fetchProjectById.fulfilled, (state, action) => {
         state.current = action.payload;

--- a/src/features/project/projectSlice.js
+++ b/src/features/project/projectSlice.js
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 import * as projectAPI from "@/api/project";
 
+// 📦 프로젝트 전체 조회
 export const fetchProjects = createAsyncThunk(
   "project/fetchProjects",
   async (_, thunkAPI) => {
@@ -8,11 +9,12 @@ export const fetchProjects = createAsyncThunk(
       const response = await projectAPI.getProjects();
       return response.data;
     } catch (error) {
-      return thunkAPI.rejectWithValue(error.response?.data || "Error");
+      return thunkAPI.rejectWithValue(error.response?.data || "프로젝트 목록 조회 실패");
     }
   }
 );
 
+// 🔍 단건 조회
 export const fetchProjectById = createAsyncThunk(
   "project/fetchProjectById",
   async (id, thunkAPI) => {
@@ -20,11 +22,12 @@ export const fetchProjectById = createAsyncThunk(
       const response = await projectAPI.getProjectById(id);
       return response.data;
     } catch (error) {
-      return thunkAPI.rejectWithValue(error.response?.data || "Error");
+      return thunkAPI.rejectWithValue(error.response?.data || "프로젝트 상세 조회 실패");
     }
   }
 );
 
+// 🆕 생성
 export const createProject = createAsyncThunk(
   "project/createProject",
   async (data, thunkAPI) => {
@@ -32,11 +35,12 @@ export const createProject = createAsyncThunk(
       const response = await projectAPI.createProject(data);
       return response.data;
     } catch (error) {
-      return thunkAPI.rejectWithValue(error.response?.data || "Error");
+      return thunkAPI.rejectWithValue(error.response?.data || "프로젝트 생성 실패");
     }
   }
 );
 
+// ✏️ 수정
 export const updateProject = createAsyncThunk(
   "project/updateProject",
   async ({ id, data }, thunkAPI) => {
@@ -44,11 +48,12 @@ export const updateProject = createAsyncThunk(
       const response = await projectAPI.updateProject(id, data);
       return response.data;
     } catch (error) {
-      return thunkAPI.rejectWithValue(error.response?.data || "Error");
+      return thunkAPI.rejectWithValue(error.response?.data || "프로젝트 수정 실패");
     }
   }
 );
 
+// ❌ 삭제
 export const deleteProject = createAsyncThunk(
   "project/deleteProject",
   async (id, thunkAPI) => {
@@ -56,7 +61,7 @@ export const deleteProject = createAsyncThunk(
       await projectAPI.deleteProject(id);
       return id;
     } catch (error) {
-      return thunkAPI.rejectWithValue(error.response?.data || "Error");
+      return thunkAPI.rejectWithValue(error.response?.data || "프로젝트 삭제 실패");
     }
   }
 );
@@ -64,8 +69,10 @@ export const deleteProject = createAsyncThunk(
 const projectSlice = createSlice({
   name: "project",
   initialState: {
-    list: [],
+    data: [],
     current: null,
+    loading: false,
+    error: null,
   },
   reducers: {
     clearCurrentProject(state) {
@@ -74,21 +81,76 @@ const projectSlice = createSlice({
   },
   extraReducers: (builder) => {
     builder
+
+      // ===== 전체 조회 =====
+      .addCase(fetchProjects.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
       .addCase(fetchProjects.fulfilled, (state, action) => {
+        state.loading = false;
         state.list = action.payload;
       })
+      .addCase(fetchProjects.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      })
+
+      // ===== 단건 조회 =====
+      .addCase(fetchProjectById.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
       .addCase(fetchProjectById.fulfilled, (state, action) => {
+        state.loading = false;
         state.current = action.payload;
       })
+      .addCase(fetchProjectById.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      })
+
+      // ===== 생성 =====
+      .addCase(createProject.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
       .addCase(createProject.fulfilled, (state, action) => {
+        state.loading = false;
         state.data.push(action.payload);
       })
+      .addCase(createProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      })
+
+      // ===== 수정 =====
+      .addCase(updateProject.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
       .addCase(updateProject.fulfilled, (state, action) => {
+        state.loading = false;
         const idx = state.data.findIndex((p) => p.id === action.payload.id);
         if (idx !== -1) state.data[idx] = action.payload;
       })
+      .addCase(updateProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      })
+
+      // ===== 삭제 =====
+      .addCase(deleteProject.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
       .addCase(deleteProject.fulfilled, (state, action) => {
+        state.loading = false;
         state.data = state.data.filter((p) => p.id !== action.payload);
+      })
+      .addCase(deleteProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
       });
   },
 });

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -1,17 +1,34 @@
-// src/routes/MainRoutes.jsx
 import React from "react";
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, Navigate } from "react-router-dom";
 import ProjectPage from "@/features/project/pages/ProjectPage";
 import ProjectDetailPage from "@/features/project/pages/ProjectDetailPage";
-// import LoginPage from "@features/auth/pages/LoginPage";
-import MainLayout from "@/layouts/MainLayout";
 import ProjectFormPage from "@/features/project/pages/ProjectFormPage";
+import MainLayout from "@/layouts/MainLayout";
+import LoginPage from "@/features/auth/pages/LoginPage";
+import { useSelector } from "react-redux";
 
 export default function MainRoutes() {
+  // const isAuthenticated = useSelector((state) => state.auth.isAuthenticated) || false; // 예시: 로그인 상태 Redux에서 가져옴
+  const isAuthenticated = null
+  
   return (
     <Routes>
-      {/* <Route path="/login" element={<LoginPage />} /> */}
+      {/* 기본 루트 경로 처리 */}
+      <Route
+        path="/"
+        element={
+          isAuthenticated ? (
+            <Navigate to="/projects" replace />
+          ) : (
+            <Navigate to="/login" replace />
+          )
+        }
+      />
 
+      {/* 로그인 페이지 */}
+      <Route path="/login" element={<LoginPage />} />
+
+      {/* 프로젝트 관련 페이지 */}
       <Route element={<MainLayout />}>
         <Route path="/projects" element={<ProjectPage />} />
         <Route path="/projects/:id" element={<ProjectDetailPage />} />

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -2,11 +2,13 @@ import { configureStore } from "@reduxjs/toolkit";
 import projectReducer from "@/features/project/projectSlice";
 import memberReducer from "@/features/member/memberSlice";
 import companyReducer from "@/features/company/companySlice";
+import authReducer from "@/features/auth/authSlice"
 
 export const store = configureStore({
   reducer: {
     project: projectReducer,
     member: memberReducer,
     company: companyReducer,
+    auth: authReducer,
   },
 });


### PR DESCRIPTION
📌 개요
프로젝트 단계(Stage) 드래그 앤 드롭 및 참여자(Participant) 관리 기능을 구현한 ProjectManagement 컴포넌트를 추가했습니다. 해당 컴포넌트는 단계 순서를 자유롭게 재배열할 수 있고, 참여자 목록에 신규 참여자를 추가하거나 기존 참여자를 삭제할 수 있습니다.

🛠️ 변경 사항
StageCard 컴포넌트 추가

useSortable 훅을 이용해 개별 단계 카드에 드래그 앤 드롭 기능 적용

MUI Card, Typography, DragIndicatorIcon 등을 사용해 카드 내부 스타일 및 테마 적용

ProjectManagement 컴포넌트 구현

stages 상태를 useState로 관리하고, DndContext + SortableContext를 통해 단계 순서 변경 로직 구현

participants 상태를 useState로 관리하고, TextField와 Button을 활용해 새 참여자 추가 기능 구현

리스트 항목별 Avatar와 DeleteIcon을 통해 참여자 삭제 기능 구현

MUI 컴포넌트(Box, Paper, List, ListItem, Divider 등)로 레이아웃 구성

테마(Theme) 참조

useTheme() 훅을 StageCard와 ProjectManagement에서 호출해 MUI 테마 팔레트를 활용하여 일관된 디자인 유지

✅ 주요 체크 포인트
 DnD 동작

DndContext와 SortableContext 설정이 올바른지

handleDragEnd에서 active.id와 over.id를 기준으로 arrayMove가 정확히 호출되는지

 참여자 추가/삭제 로직

handleAddParticipant 함수가 빈 문자열 입력 시 무시하도록 예외 처리되었는지

신규 참여자 ID 생성 로직(기존 최대 ID + 1)이 충돌 없이 작동하는지

handleRemoveParticipant 함수가 상태에서 해당 ID만 제거하는지

 UI 렌더링/레이아웃

단계 카드(flex-wrap)가 화면 크기에 따라 줄바꿈되어 표시되는지

마지막 참여자 항목 뒤에 Divider가 남지 않는지

MUI sx 속성을 통해 적절한 패딩/마진이 설정되었는지

🔁 테스트 결과
단계 순서 변경 테스트

단계 카드를 드래그하여 다른 위치로 이동 → stages 상태가 업데이트되고 화면에 즉시 반영됨

순서가 변경된 상태에서 새로고침하지 않아도 위치가 유지됨

참여자 추가 테스트

이름을 입력하지 않고 “추가” 클릭 시 아무 동작도 하지 않음

“홍길동” 입력 후 “추가” 클릭 시 목록 하단에 새 참여자 항목이 생성됨

새 참여자의 ID가 기존 최대 ID + 1로 자동 부여됨

참여자 삭제 테스트

참여자 항목 옆 휴지통 아이콘 클릭 시 해당 항목이 목록에서 제거됨

마지막 참여자를 삭제해도 레이아웃이 깨지지 않음

반응형 레이아웃 확인

화면 크기를 줄여도 단계 카드가 줄바꿈되어 보이고,

텍스트 크기가 { xs: 14, sm: 15 }로 적절히 조정되는 것을 확인함

🔗 연관된 이슈
- #123 – 프로젝트 관리 화면 구현 이슈

- #124 – 참여자 목록 CRUD 기능 요구 사항

📑 레퍼런스
MUI Documentation – Card

@dnd-kit/core Documentation

@dnd-kit/sortable Documentation