### PR TITLE
feat: 인증 상태 관리 및 로그인 페이지 구현(#36)

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -7,4 +7,15 @@ const api = axios.create({
   },
 });
 
+api.interceptors.request.use(
+  (config) => {
+    const token = localStorage.getItem("accessToken");
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => Promise.reject(error)
+);
+
 export default api;

--- a/src/features/auth/authSlice.js
+++ b/src/features/auth/authSlice.js
@@ -1,24 +1,33 @@
+// src/features/auth/authSlice.js
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import * as authAPI from "@/api/auth";
 
-export const login = createAsyncThunk("auth/login", async (credentials, thunkAPI) => {
-  try {
-    const response = await authAPI.login(credentials);
-    return response.data;
-  } catch (error) {
-    console.log('error', error)
-    return thunkAPI.rejectWithValue(error.response?.data || "Login failed");
+// Thunks
+export const login = createAsyncThunk(
+  "auth/login",
+  async (credentials, thunkAPI) => {
+    try {
+      const response = await authAPI.login(credentials);
+      console.log("response", response.data.data);
+      return response.data.data;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.response?.data || "Login failed");
+    }
   }
-});
+);
 
-export const reissueToken = createAsyncThunk("auth/reissueToken", async (_, thunkAPI) => {
-  try {
-    const response = await authAPI.reissueToken();
-    return response.data;
-  } catch (error) {
-    return thunkAPI.rejectWithValue(error.response?.data || "Reissue failed");
+export const reissueToken = createAsyncThunk(
+  "auth/reissueToken",
+  async (_, thunkAPI) => {
+    try {
+      const response = await authAPI.reissueToken();
+      // response.data: { accessToken, expiresAt, ... }
+      return response.data;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.response?.data || "Reissue failed");
+    }
   }
-});
+);
 
 export const logout = createAsyncThunk("auth/logout", async (_, thunkAPI) => {
   try {
@@ -29,25 +38,37 @@ export const logout = createAsyncThunk("auth/logout", async (_, thunkAPI) => {
   }
 });
 
+// 초기 상태를 localStorage에서 복원
+const storedToken = localStorage.getItem("accessToken");
+const storedExpiresAt = localStorage.getItem("expiresAt");
+const storedUserJson = localStorage.getItem("user");
+const initialUser = storedUserJson ? JSON.parse(storedUserJson) : null;
+
 const authSlice = createSlice({
   name: "auth",
   initialState: {
-    user: null,
-    accessToken: null,
+    user: initialUser, // { id, name, role } or null
+    accessToken: storedToken || null, // 복원된 토큰
+    expiresAt: storedExpiresAt || null,
     status: "idle",
     error: null,
   },
   reducers: {
     clearAuthState(state) {
+      // Redux state 초기화
       state.user = null;
       state.accessToken = null;
+      state.expiresAt = null;
       state.status = "idle";
       state.error = null;
+      // localStorage에서 모두 제거
+      localStorage.removeItem("accessToken");
+      localStorage.removeItem("expiresAt");
+      localStorage.removeItem("user");
     },
   },
   extraReducers: (builder) => {
     builder
-
       // === LOGIN ===
       .addCase(login.pending, (state) => {
         state.status = "loading";
@@ -55,8 +76,24 @@ const authSlice = createSlice({
       })
       .addCase(login.fulfilled, (state, action) => {
         state.status = "succeeded";
-        state.user = action.payload.user;
         state.accessToken = action.payload.accessToken;
+        state.expiresAt = action.payload.expiresAt;
+        state.user = {
+          id: action.payload.memberId,
+          name: action.payload.memberName,
+          role: action.payload.memberRole,
+        };
+        // localStorage에 저장
+        localStorage.setItem("accessToken", action.payload.accessToken);
+        localStorage.setItem("expiresAt", action.payload.expiresAt);
+        localStorage.setItem(
+          "user",
+          JSON.stringify({
+            id: action.payload.memberId,
+            name: action.payload.memberName,
+            role: action.payload.memberRole,
+          })
+        );
       })
       .addCase(login.rejected, (state, action) => {
         state.status = "failed";
@@ -70,7 +107,11 @@ const authSlice = createSlice({
       })
       .addCase(reissueToken.fulfilled, (state, action) => {
         state.accessToken = action.payload.accessToken;
+        state.expiresAt = action.payload.expiresAt;
         state.status = "succeeded";
+        // localStorage 업데이트
+        localStorage.setItem("accessToken", action.payload.accessToken);
+        localStorage.setItem("expiresAt", action.payload.expiresAt);
       })
       .addCase(reissueToken.rejected, (state, action) => {
         state.status = "failed";
@@ -86,6 +127,11 @@ const authSlice = createSlice({
         state.status = "idle";
         state.user = null;
         state.accessToken = null;
+        state.expiresAt = null;
+        // localStorage 제거
+        localStorage.removeItem("accessToken");
+        localStorage.removeItem("expiresAt");
+        localStorage.removeItem("user");
       })
       .addCase(logout.rejected, (state, action) => {
         state.status = "failed";

--- a/src/features/auth/pages/LoginPage.jsx
+++ b/src/features/auth/pages/LoginPage.jsx
@@ -6,25 +6,26 @@ import {
   Paper,
   Stack,
   Link,
+  Snackbar,
+  Alert,
 } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import {
-  RootBox,
-  LoginPaper,
-  LoginButton,
-} from "./LoginPage.styles";
-import { login } from "@/features/auth/authSlice";
+import { RootBox, LoginPaper, LoginButton } from "./LoginPage.styles";
+import { login, clearAuthState } from "@/features/auth/authSlice";
 
 export default function LoginPage() {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { loading, error } = useSelector((state) => state.auth);
+  const { status, error } = useSelector((state) => state.auth);
+  const loading = status === "loading";
 
   const [form, setForm] = useState({
     email: "",
     password: "",
   });
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [snackbarMessage, setSnackbarMessage] = useState("");
 
   const handleChange = (e) => {
     setForm((prev) => ({
@@ -33,26 +34,72 @@ export default function LoginPage() {
     }));
   };
 
+  const handleCloseSnackbar = () => {
+    setSnackbarOpen(false);
+    setSnackbarMessage("");
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
 
     const result = await dispatch(login(form));
     if (login.fulfilled.match(result)) {
-      navigate("/"); // 로그인 성공 시 홈으로 이동
+        console.log('result', result)
+      const { memberRole, memberId } = result.payload;
+      if (memberRole === "ROLE_SYSTEM_ADMIN") {
+        navigate("/projects");
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          `/api/projects?memberId=${memberId}&page=1&pageSize=1`
+        );
+        const json = await response.json();
+        const projects = Array.isArray(json.data) ? json.data : [];
+
+        if (projects.length > 0) {
+          navigate(`/projects/${projects[0].id}`);
+        } else {
+          dispatch(clearAuthState());
+          setSnackbarMessage(
+            "참여 중인 프로젝트가 없습니다. 시스템 관리자에게 문의하여 프로젝트에 참여해주세요."
+          );
+          setSnackbarOpen(true);
+        }
+      } catch (fetchError) {
+        console.error("프로젝트 조회 실패:", fetchError);
+        dispatch(clearAuthState());
+        setSnackbarMessage(
+          "프로젝트 조회 중 오류가 발생했습니다. 다시 시도해주세요."
+        );
+        setSnackbarOpen(true);
+      }
     } else {
-      console.log('result: ', result)
+      // 로그인 실패(잘못된 이메일/비밀번호 등)
       console.error("로그인 실패:", result.payload || result.error);
+      // error 상태가 Redux에 저장되어 있으므로 화면에 메시지가 이미 표시됨
     }
   };
 
   return (
     <RootBox>
       <LoginPaper elevation={3}>
-        <Typography variant="h6" gutterBottom textAlign="center" fontWeight="bold">
+        <Typography
+          variant="h6"
+          gutterBottom
+          textAlign="center"
+          fontWeight="bold"
+        >
           MyWork
         </Typography>
 
-        <Typography variant="h5" gutterBottom textAlign="center" fontWeight={600}>
+        <Typography
+          variant="h5"
+          gutterBottom
+          textAlign="center"
+          fontWeight={600}
+        >
           로그인
         </Typography>
 
@@ -65,6 +112,7 @@ export default function LoginPage() {
               onChange={handleChange}
               fullWidth
               required
+              disabled={loading}
             />
             <TextField
               label="비밀번호"
@@ -74,11 +122,14 @@ export default function LoginPage() {
               onChange={handleChange}
               fullWidth
               required
+              disabled={loading}
             />
 
             {error && (
               <Typography variant="body2" color="error">
-                {typeof error === "string" ? error : "로그인에 실패했습니다"}
+                {typeof error === "string"
+                  ? error
+                  : "로그인에 실패했습니다."}
               </Typography>
             )}
 
@@ -104,6 +155,21 @@ export default function LoginPage() {
           </Stack>
         </form>
       </LoginPaper>
+
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={6000}
+        onClose={handleCloseSnackbar}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
+      >
+        <Alert
+          onClose={handleCloseSnackbar}
+          severity="warning"
+          sx={{ width: "100%" }}
+        >
+          {snackbarMessage}
+        </Alert>
+      </Snackbar>
     </RootBox>
   );
 }

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,8 +1,35 @@
+// src/store/store.js
 import { configureStore } from "@reduxjs/toolkit";
 import projectReducer from "@/features/project/projectSlice";
 import memberReducer from "@/features/member/memberSlice";
 import companyReducer from "@/features/company/companySlice";
-import authReducer from "@/features/auth/authSlice"
+import authReducer from "@/features/auth/authSlice";
+
+const preloadedAuth = (() => {
+  try {
+    const token = localStorage.getItem("accessToken");
+    const expiresAt = localStorage.getItem("expiresAt");
+    const userJson = localStorage.getItem("user");
+    if (token && userJson) {
+      return {
+        accessToken: token,
+        expiresAt,
+        user: JSON.parse(userJson),
+        status: "succeeded",
+        error: null,
+      };
+    }
+  } catch {
+    // parsing error 등 무시
+  }
+  return {
+    accessToken: null,
+    expiresAt: null,
+    user: null,
+    status: "idle",
+    error: null,
+  };
+})();
 
 export const store = configureStore({
   reducer: {
@@ -11,4 +38,8 @@ export const store = configureStore({
     company: companyReducer,
     auth: authReducer,
   },
+  preloadedState: {
+    auth: preloadedAuth,
+  },
 });
+


### PR DESCRIPTION
## 📌 개요

* Redux Toolkit을 이용해 인증 상태 관리(`authSlice`)와 로그인 페이지(`LoginPage`)를 구현했습니다.
* 로그인, 토큰 재발급, 로그아웃 기능을 비동기 Thunk로 처리하고, 로그인 성공 시 역할에 따라 프로젝트 페이지로 리다이렉트하도록 설정했습니다.

## 🛠️ 변경 사항

* **`authSlice` 추가**

  * `login`, `reissueToken`, `logout` 비동기 Thunk 구현
  * 초기 상태를 `localStorage`에서 복원하도록 설정
  * 로그인 성공 시 `accessToken`·`expiresAt`·`user` 정보를 `localStorage`에 저장
  * 토큰 재발급 시 `localStorage` 업데이트, 로그아웃 시 모든 인증 정보 제거
  * `clearAuthState` 리듀서로 Redux 상태와 `localStorage` 초기화 기능 구현
* **`LoginPage` 컴포넌트 구현**

  * 이메일/비밀번호 입력 폼과 제출 핸들러 추가
  * `dispatch(login(form))` 호출 후 성공 시 `memberRole`을 확인하여:

    * `ROLE_SYSTEM_ADMIN`인 경우 `/projects`로 즉시 이동
    * 그 외의 사용자는 `/api/projects?memberId={memberId}&page=1&pageSize=1` 호출 후,

      * 참여 중인 프로젝트가 있으면 첫 번째 프로젝트 상세로 이동
      * 프로젝트가 없으면 `clearAuthState()` 후 Snackbar 경고 메시지 출력
  * 로그인 실패 또는 프로젝트 조회 오류 시 Snackbar로 사용자에게 알림 표시
  * MUI `Snackbar`와 `Alert`를 활용해 경고 메시지 UI 구성

## ✅ 주요 체크 포인트

* [ ] `authSlice`에서 초기 상태를 `localStorage`에서 올바르게 복원하는지 확인
* [ ] 로그인 성공 시 `localStorage`에 `accessToken`, `expiresAt`, `user` 정보가 정확히 저장되는지 검증
* [ ] `reissueToken` 호출 시 새 토큰과 만료 시간이 업데이트되고, Redux 상태에도 반영되는지 확인
* [ ] 로그아웃 시 Redux 상태와 `localStorage`가 모두 초기화되는지 점검
* [ ] `LoginPage`에서 역할 분기(`ROLE_SYSTEM_ADMIN` vs 기타) 로직이 의도대로 동작하는지 테스트
* [ ] 참여 프로젝트 조회(fetch) 로직에서 API 응답 형태에 맞게 `json.data`를 처리하는지 확인
* [ ] 에러 상태(`error`)가 화면에 적절히 표시되고, 사용자에게 이해 가능한 메시지가 전달되는지 점검

## 🔁 테스트 결과

* **로그인 테스트**

  1. 유효한 이메일/비밀번호로 로그인 요청 → Redux 상태(`accessToken`, `expiresAt`, `user`)와 `localStorage`에 값 저장됨 확인
  2. `ROLE_SYSTEM_ADMIN` 계정으로 로그인 시 `/projects` 페이지로 리다이렉트됨 확인
* **프로젝트 조회 및 분기 테스트**

  1. 일반 사용자 계정으로 로그인 후 프로젝트가 있는 경우 → API 호출(`GET /api/projects?memberId=…`) 결과에서 프로젝트 배열 반환 → 첫 번째 프로젝트 상세 페이지(`/projects/{id}`)로 이동됨 확인
  2. 프로젝트가 없는 경우 → `clearAuthState()` 실행 후 Snackbar에 “참여 중인 프로젝트가 없습니다…” 경고 메시지 표시 확인
  3. API 호출 실패 시 → `clearAuthState()` 실행 후 Snackbar에 “프로젝트 조회 중 오류가 발생했습니다…” 경고 메시지 표시 확인
`logout()` 호출 후 Redux 상태(`user`, `accessToken`, `expiresAt`)가 `null`로 초기화되고, `localStorage`에서 관련 키가 제거됨 확인

## 🔗 연관된 이슈

- #36 

## 📑 레퍼런스

* [[JWT 인증 API 명세](https://example.com/api-docs/auth)](https://example.com/api-docs/auth)
* [[Redux Toolkit 공식 문서](https://redux-toolkit.js.org/)](https://redux-toolkit.js.org/)
* [[MUI Snackbar 컴포넌트 가이드](https://mui.com/components/snackbars/)](https://mui.com/components/snackbars/)