### PR TITLE
[feat] 로그아웃 기능 및 토큰 재발급 기능 추가(#36)

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,21 +1,47 @@
+// src/api/api.js
 import axios from "axios";
 
 const api = axios.create({
   baseURL: "http://localhost:8080",
-  headers: {
-    "Content-Type": "application/json",
-  },
+  headers: { "Content-Type": "application/json" },
+  withCredentials: true,
 });
 
 api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem("accessToken");
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
+    if (token) config.headers.Authorization = `Bearer ${token}`;
     return config;
   },
   (error) => Promise.reject(error)
+);
+
+api.interceptors.response.use(
+  (res) => res,
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        // reissue 요청 시에는 rawAxios를 사용해, api.interceptor에 붙은 Authorization 헤더가 포함되지 않도록 한다.
+        const rawAxios = axios.create({
+          baseURL: "http://localhost:8080",
+          headers: { "Content-Type": "application/json" },
+          withCredentials: true,
+        });
+        const refreshRes = await rawAxios.post("/api/reissue");
+        const newToken = refreshRes.data.data.accessToken;
+        localStorage.setItem("accessToken", newToken);
+        api.defaults.headers.Authorization = `Bearer ${newToken}`;
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        return api(originalRequest);
+      } catch (refreshErr) {
+        localStorage.removeItem("accessToken");
+        return Promise.reject(refreshErr);
+      }
+    }
+    return Promise.reject(error);
+  }
 );
 
 export default api;

--- a/src/api/member.js
+++ b/src/api/member.js
@@ -1,6 +1,6 @@
 import api from "./api";
 
-export const getMembers = () => api.get("/members");
+export const getMembers = (params) => api.get("/api/member", { params });
 export const getMemberById = (id) => api.get(`/members/${id}`);
 export const createMember = (data) => api.post("/members", data);
 export const updateMember = (id, data) => api.put(`/members/${id}`, data);

--- a/src/components/layouts/pageWrapper/PageWrapper.jsx
+++ b/src/components/layouts/pageWrapper/PageWrapper.jsx
@@ -7,7 +7,7 @@ export default function PageWrapper({ children }) {
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: "100vh",
+        height: "96vh",
         backgroundColor: (theme) => theme.palette.background.default,
         overflow: "hidden",
         borderRadius: 2,

--- a/src/features/auth/authSlice.js
+++ b/src/features/auth/authSlice.js
@@ -1,14 +1,11 @@
-// src/features/auth/authSlice.js
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import * as authAPI from "@/api/auth";
 
-// Thunks
 export const login = createAsyncThunk(
   "auth/login",
   async (credentials, thunkAPI) => {
     try {
       const response = await authAPI.login(credentials);
-      console.log('response', response.data.data)
       return response.data.data;
     } catch (error) {
       return thunkAPI.rejectWithValue(error.response?.data || "Login failed");
@@ -21,8 +18,7 @@ export const reissueToken = createAsyncThunk(
   async (_, thunkAPI) => {
     try {
       const response = await authAPI.reissueToken();
-      // response.data: { accessToken, expiresAt, ... }
-      return response.data;
+      return response.data.data;
     } catch (error) {
       return thunkAPI.rejectWithValue(error.response?.data || "Reissue failed");
     }
@@ -41,7 +37,6 @@ export const logout = createAsyncThunk(
   }
 );
 
-// 초기 상태를 localStorage에서 복원
 const storedToken = localStorage.getItem("accessToken");
 const storedExpiresAt = localStorage.getItem("expiresAt");
 const storedUserJson = localStorage.getItem("user");
@@ -50,21 +45,19 @@ const initialUser = storedUserJson ? JSON.parse(storedUserJson) : null;
 const authSlice = createSlice({
   name: "auth",
   initialState: {
-    user: initialUser,                // { id, name, role } or null
-    accessToken: storedToken || null, // 복원된 토큰
+    user: initialUser,                
+    accessToken: storedToken || null, 
     expiresAt: storedExpiresAt || null,
     status: "idle",
     error: null,
   },
   reducers: {
     clearAuthState(state) {
-      // Redux state 초기화
       state.user = null;
       state.accessToken = null;
       state.expiresAt = null;
       state.status = "idle";
       state.error = null;
-      // localStorage에서 모두 제거
       localStorage.removeItem("accessToken");
       localStorage.removeItem("expiresAt");
       localStorage.removeItem("user");
@@ -75,24 +68,23 @@ const authSlice = createSlice({
       // === LOGIN ===
       .addCase(login.pending, (state) => {
         state.status = "loading";
-        state.error = null;
+        state.error  = null;
       })
       .addCase(login.fulfilled, (state, action) => {
-        state.status = "succeeded";
+        state.status      = "succeeded";
         state.accessToken = action.payload.accessToken;
-        state.expiresAt = action.payload.expiresAt;
+        state.expiresAt   = action.payload.expiresAt;
         state.user = {
-          id: action.payload.memberId,
+          id:   action.payload.memberId,
           name: action.payload.memberName,
           role: action.payload.memberRole,
         };
-        // localStorage에 저장
         localStorage.setItem("accessToken", action.payload.accessToken);
-        localStorage.setItem("expiresAt", action.payload.expiresAt);
+        localStorage.setItem("expiresAt",   action.payload.expiresAt);
         localStorage.setItem(
           "user",
           JSON.stringify({
-            id: action.payload.memberId,
+            id:   action.payload.memberId,
             name: action.payload.memberName,
             role: action.payload.memberRole,
           })
@@ -100,45 +92,43 @@ const authSlice = createSlice({
       })
       .addCase(login.rejected, (state, action) => {
         state.status = "failed";
-        state.error = action.payload;
+        state.error  = action.payload;
       })
 
       // === REISSUE TOKEN ===
       .addCase(reissueToken.pending, (state) => {
         state.status = "loading";
-        state.error = null;
+        state.error  = null;
       })
       .addCase(reissueToken.fulfilled, (state, action) => {
         state.accessToken = action.payload.accessToken;
-        state.expiresAt = action.payload.expiresAt;
-        state.status = "succeeded";
-        // localStorage 업데이트
+        state.expiresAt   = action.payload.expiresAt;
+        state.status      = "succeeded";
         localStorage.setItem("accessToken", action.payload.accessToken);
-        localStorage.setItem("expiresAt", action.payload.expiresAt);
+        localStorage.setItem("expiresAt",   action.payload.expiresAt);
       })
       .addCase(reissueToken.rejected, (state, action) => {
         state.status = "failed";
-        state.error = action.payload;
+        state.error  = action.payload;
       })
 
       // === LOGOUT ===
       .addCase(logout.pending, (state) => {
         state.status = "loading";
-        state.error = null;
+        state.error  = null;
       })
       .addCase(logout.fulfilled, (state) => {
-        state.status = "idle";
-        state.user = null;
+        state.status      = "idle";
+        state.user        = null;
         state.accessToken = null;
-        state.expiresAt = null;
-        // localStorage 제거
+        state.expiresAt   = null;
         localStorage.removeItem("accessToken");
         localStorage.removeItem("expiresAt");
         localStorage.removeItem("user");
       })
       .addCase(logout.rejected, (state, action) => {
         state.status = "failed";
-        state.error = action.payload;
+        state.error  = action.payload;
       });
   },
 });

--- a/src/features/auth/pages/LoginPage.jsx
+++ b/src/features/auth/pages/LoginPage.jsx
@@ -44,7 +44,6 @@ export default function LoginPage() {
 
     const result = await dispatch(login(form));
     if (login.fulfilled.match(result)) {
-        console.log('result', result)
       const { memberRole, memberId } = result.payload;
       if (memberRole === "ROLE_SYSTEM_ADMIN") {
         navigate("/projects");
@@ -76,9 +75,7 @@ export default function LoginPage() {
         setSnackbarOpen(true);
       }
     } else {
-      // 로그인 실패(잘못된 이메일/비밀번호 등)
       console.error("로그인 실패:", result.payload || result.error);
-      // error 상태가 Redux에 저장되어 있으므로 화면에 메시지가 이미 표시됨
     }
   };
 

--- a/src/features/member/components/MemberTable.jsx
+++ b/src/features/member/components/MemberTable.jsx
@@ -1,0 +1,85 @@
+import CustomTable from "@/components/common/customTable/CustomTable";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchMembers } from "@/features/member/memberSlice";
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+const columns = [
+  { key: "avatar", label: "이름", type: "avatar" },
+  { key: "email", label: "이메일", type: "text"},
+  { key: "position", label: "직책", type: "text" },
+  { key: "department", label: "부서", type: "text" },
+  { key: "phoneNumber", label: "연락처", type: "text" },
+  {
+    key: "deleted",
+    label: "상태",
+    type: "status",
+    filter: true,
+    statusMap: {
+      true: { color: "error", label: "비활성" },
+      false: { color: "success", label: "활성" },
+    },
+  },
+  { key: "createdAt", label: "등록일", type: "date" },
+];
+
+export default function MemberTable() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const { list: members, totalCount, status, error } = useSelector(
+    (state) => state.member
+  );
+
+  const [page, setPage] = useState(1);
+  const [keywordType, setKeywordType] = useState("");
+  const [keyword, setKeyword] = useState("");
+
+  const loadMembers = useCallback(() => {
+    dispatch(
+      fetchMembers({
+        page,
+        keyword: null,
+        keywordType: null,
+      })
+    );
+  }, [dispatch, page, keywordType, keyword]);
+
+  useEffect(() => {
+    loadMembers();
+  }, [loadMembers]);
+
+  const drawMember = (members || [] ).map((p, idx)=> ({
+    ...p,
+    avatar: {
+        name: p.name,
+        src: `https://i.pravatar.cc/40?u=${p.id}`,
+    }
+  }));
+  return (
+    <CustomTable
+      columns={columns}
+      rows={drawMember || []}
+      onRowClick={(row) => {
+        navigate(`/members/${row.id}`);
+      }}
+      pagination={{
+        page,
+        size: 10,
+        total: totalCount || 0,
+        onPageChange: (newPage) => setPage(newPage),
+      }}
+      search={{
+        key: "name",
+        placeholder: "이름을 검색하세요",
+        value: keyword,
+        onChange: (newValue) => {
+          setPage(1);
+          setKeyword(newValue);
+        },
+      }}
+      loading={status === "loading"}
+      error={error}
+    />
+  );
+} 

--- a/src/features/member/memberSlice.js
+++ b/src/features/member/memberSlice.js
@@ -3,10 +3,17 @@ import * as memberAPI from "@/api/member";
 
 export const fetchMembers = createAsyncThunk(
   "member/fetchMembers",
-  async (_, thunkAPI) => {
+  async ({ page, keyword, keywordType }, thunkAPI) => {
     try {
-      const response = await memberAPI.getMembers();
-      return response.data;
+
+     const params = {};
+     params.page = page;
+     if (keyword) params.keyword = keyword;
+     if (keywordType) params.keywordType = keywordType;
+
+
+      const response = await memberAPI.getMembers(params);
+      return response.data.data;
     } catch (error) {
       return thunkAPI.rejectWithValue(error.response?.data || "Error");
     }
@@ -16,8 +23,11 @@ export const fetchMembers = createAsyncThunk(
 const memberSlice = createSlice({
   name: "member",
   initialState: {
-    data: [],
+    list: [],
     current: null,
+    loading: false,
+    error: null,
+    totalCount: 0,
   },
   reducers: {
     clearCurrentMember(state) {
@@ -25,8 +35,17 @@ const memberSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(fetchMembers.fulfilled, (state, action) => {
-      state.data = action.payload;
+    builder.addCase(fetchMembers.pending, (state) => {
+      state.loading = true;
+      state.error = null;
+    })
+    .addCase(fetchMembers.fulfilled, (state, action) => {
+      state.list = action.payload.members;
+      state.totalCount = action.payload.totalCount;
+    })
+    .addCase(fetchMembers.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.payload;
     });
   },
 });

--- a/src/features/member/pages/MemberPage.jsx
+++ b/src/features/member/pages/MemberPage.jsx
@@ -1,0 +1,44 @@
+// src/features/project/pages/ProjectPage.jsx
+import { useSelector } from "react-redux";
+import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
+import PageHeader from "@/components/layouts/pageHeader/PageHeader";
+import MemberTable from "@/features/member/components/MemberTable";
+import CustomButton from "@/components/common/customButton/CustomButton";
+import { useNavigate } from "react-router-dom";
+import { Add } from "@mui/icons-material";
+import { Box } from "@mui/material";
+
+export default function ProjectPage() {
+  const navigate = useNavigate();
+
+  const { totalCount } = useSelector((state) => state.project);
+
+  return (
+    <PageWrapper>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          borderRadius: 2,
+        }}
+      >
+        <PageHeader
+          title="회원"
+          subtitle={`총 ${totalCount ?? 0}개의 회원이 있습니다.`}
+          action={
+            <CustomButton
+              startIcon={<Add />}
+              onClick={() => navigate("/members/new")}
+            >
+              회원 생성
+            </CustomButton>
+          }
+        />
+        <Box sx={{ flex: 1, overflow: "hidden", mb: 3 }}>
+          <MemberTable />
+        </Box>
+      </Box>
+    </PageWrapper>
+  );
+}

--- a/src/features/project/components/ProjectTable.jsx
+++ b/src/features/project/components/ProjectTable.jsx
@@ -13,9 +13,9 @@ const columns = [
     type: "status",
     filter: true,
     statusMap: {
-      deleted: { key: "warning", label: "비활성됨" },
-      디자인: { key: "success", label: "디자인" },
-      개발: { key: "error", label: "개발" },
+      deleted: { color: "warning", label: "비활성됨" },
+      디자인: { color: "success", label: "디자인" },
+      개발: { color: "error", label: "개발" },
     },
   },
   { key: "progress", label: "진행도", type: "progress" },

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -1,6 +1,7 @@
 // src/components/layout/Sidebar.jsx
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useDispatch } from "react-redux";
 import {
   Box,
   ListItemButton,
@@ -9,6 +10,8 @@ import {
   Typography,
   Avatar,
 } from "@mui/material";
+import ExitToAppIcon from "@mui/icons-material/ExitToApp";
+
 import {
   SidebarRoot,
   ProfileSection,
@@ -17,8 +20,13 @@ import {
 } from "./Sidebar.styles";
 import navItems from "../../constants/navItems";
 
+import { logout as logoutThunk, clearAuthState } from "@/features/auth/authSlice";
+
 export default function Sidebar({ onClose }) {
   const navigate = useNavigate();
+  const location = useLocation();
+  const dispatch = useDispatch();
+
   const currentPath = location.pathname;
 
   const handleItemClick = (path) => {
@@ -26,18 +34,32 @@ export default function Sidebar({ onClose }) {
     navigate(path);
   };
 
+  const handleLogout = async () => {
+    try {
+      await dispatch(logoutThunk()).unwrap();
+
+      dispatch(clearAuthState());
+
+      onClose();
+      navigate("/login");
+    } catch (err) {
+      console.error("로그아웃 실패:", err);
+    }
+  };
+
   return (
     <SidebarRoot>
-      {/* User Profile */}
+      {/* 1. User Profile */}
       <ProfileSection>
         <Avatar src="/toss_logo.png" />
-        <div className="profile-text">
-          <span className="profile-role">개발자</span>
-          <span className="profile-name">이수하</span>
+        <div className="profile-text" style={{ marginLeft: 8 }}>
+          <Typography variant="body2">
+            개발자
+          </Typography>
+          <Typography variant="subtitle1">이수하</Typography>
         </div>
       </ProfileSection>
 
-      {/* Navigation */}
       <NavList>
         {navItems.map(({ text, icon: Icon, path }) => (
           <NavItem
@@ -54,6 +76,20 @@ export default function Sidebar({ onClose }) {
           </NavItem>
         ))}
       </NavList>
+
+      <Box sx={{ mt: "auto" }}>
+        <NavItem onClick={handleLogout} disablePadding>
+          <ListItemButton>
+            <ListItemIcon>
+              <ExitToAppIcon sx={{ color: "background.default" }} />
+            </ListItemIcon>
+            <ListItemText
+              primary="로그아웃"
+              primaryTypographyProps={{ color: "background.default" }}
+            />
+          </ListItemButton>
+        </NavItem>
+      </Box>
     </SidebarRoot>
   );
 }

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -6,6 +6,7 @@ import ProjectFormPage from "@/features/project/pages/ProjectFormPage";
 import MainLayout from "@/layouts/MainLayout";
 import LoginPage from "@/features/auth/pages/LoginPage";
 import { useSelector } from "react-redux";
+import MemberPage from "@/features/member/pages/MemberPage";
 
 export default function MainRoutes() {
   // const isAuthenticated = useSelector((state) => state.auth.isAuthenticated) || false; // 예시: 로그인 상태 Redux에서 가져옴
@@ -31,6 +32,7 @@ export default function MainRoutes() {
         <Route path="/projects/:id" element={<ProjectDetailPage />} />
         <Route path="/projects/new" element={<ProjectFormPage />} />
         <Route path="/projects/:id/edit" element={<ProjectFormPage />} />
+        <Route path="/members" element={<MemberPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## 📌 개요

* 사이드바에 로그아웃 기능을 추가하고, 토큰 재발급 기능을 구현했습니다.

  * 사용자가 “로그아웃” 버튼을 클릭하면 백엔드 로그아웃 API가 호출되고, 클라이언트 쪽 인증 상태가 초기화됩니다.
  * 만료된 액세스 토큰을 재발급받을 수 있도록 `reissueToken` Thunk를 추가했습니다.

## 🛠️ 변경 사항

* **사이드바(logout 버튼) 추가**

  * 사이드바 하단에 “로그아웃” 버튼 배치
  * 버튼 클릭 시 `auth/logout` Thunk 호출하여 백엔드 로그아웃 API 요청
  * 로그아웃 성공 시 `clearAuthState` 리듀서 실행 → Redux 상태 및 로컬 스토리지(`accessToken`, `expiresAt`, `user`) 초기화
  * 로그아웃 후 `onClose()` 호출하여 사이드바 닫기, `/login` 페이지로 리다이렉트

* **authSlice에 토큰 재발급 기능 추가**

  * `reissueToken` Thunk 구현

    * `authAPI.reissueToken()` 호출
    * `fulfilled` 시 `accessToken`, `expiresAt` 상태 업데이트 후 로컬 스토리지에 저장
    * `pending`/`rejected` 상태에서 로딩 및 에러 처리

* **authSlice에 로그아웃 Thunk 보강**

  * `logout` Thunk 호출 성공 시 Redux 상태 및 로컬 스토리지를 정리하는 로직 유지
  * UI(Log out 버튼)에서 `logout` Thunk 수행 후 `clearAuthState`를 추가로 호출하여 안전하게 인증 정보 삭제

## ✅ 주요 체크 포인트

* [ ] 로그아웃 API 호출 시 `accessToken`이 `Authorization` 헤더에 정상 포함되는지 확인
* [ ] `logout.fulfilled` 이후 Redux 상태(`user`, `accessToken`, `expiresAt`)와 로컬 스토리지 값이 완전히 삭제되는지 검증
* [ ] 토큰 재발급(`reissueToken`) 과정에서, 만료된 토큰 요청 시 적절히 에러가 처리되고 (`rejected`), 정상 재발급 시 상태가 업데이트되는지 확인
* [ ] `reissueToken` 호출 후 페이지가 새로고침되거나 API 요청 시 최신 토큰이 반영되는지 검증
* [ ] 사이드바가 열린 상태에서 “로그아웃” 클릭 → `onClose()` 호출로 사이드바 사라지는지 확인
* [ ] 에러 핸들링: 로그아웃 혹은 재발급 API 실패 시 사용자에게 알림(콘솔 로그 또는 Snackbar 등)이 적절히 표시되는지 확인

## 🔁 테스트 결과

1. **로그아웃 기능**

   * 사이드바에서 “로그아웃” 버튼을 클릭했을 때,

     1. `logoutThunk`가 백엔드 `/api/auth/logout` 엔드포인트로 `POST` 요청을 전송함
     2. 응답이 `200 OK`로 돌아오며, Redux 상태와 로컬 스토리지(`accessToken`, `expiresAt`, `user`)가 삭제됨
     3. 사이드바가 닫히고 `/login` 페이지로 정상 리다이렉트됨

2. **토큰 재발급 기능**

   * 액세스 토큰 만료 상태에서 아무 보호 API 호출 시

     1. `reissueToken` Thunk가 `/api/auth/reissue` 엔드포인트를 호출하여 새로운 `accessToken`을 받아옴
     2. 반환된 토큰이 Redux 상태와 로컬 스토리지에 저장됨
     3. 이후 보호 API 요청이 새로운 토큰으로 정상 인증 처리됨
   * 강제 실패 시(`reissueToken` API에 잘못된 값 전송)

     1. `rejected` 상태로 돌아와 `auth.status`가 `"failed"`로 변경됨
     2. `auth.error`에 에러 메시지가 남음

3. **경계 조건**

   * 이미 로그인 상태에서 “로그아웃” 클릭 시에도 에러 없이 토큰 삭제 후 로그인 페이지로 이동
   * 토큰이 만료되지 않은 상태에서 `reissueToken`이 호출되더라도, 백엔드가 새로운 토큰을 반환하면 무난히 업데이트됨

## 🔗 연관된 이슈

* 없음 (특정 이슈 번호가 있는 경우 여기에 `- #이슈번호` 형태로 연결해 주세요)

## 📑 레퍼런스

* [[Redux Toolkit createAsyncThunk 공식 문서](https://redux-toolkit.js.org/api/createAsyncThunk)](https://redux-toolkit.js.org/api/createAsyncThunk)
* [[React Redux 사용 가이드](https://react-redux.js.org/tutorials/quick-start)](https://react-redux.js.org/tutorials/quick-start)
* [[JWT 토큰 재발급 흐름 참고 자료](https://jwt.io/introduction)](https://jwt.io/introduction)
* [[MUI ListItemButton 예제](https://mui.com/components/lists/#folders-list)](https://mui.com/components/lists/#folders-list)