### PR TITLE
[feat] Axios 응답 인터셉터에 토큰 재발급 실패 시 로그인 페이지 리디렉션 로직 추가(#36)

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -20,26 +20,38 @@ api.interceptors.response.use(
   (res) => res,
   async (error) => {
     const originalRequest = error.config;
+
     if (error.response?.status === 401 && !originalRequest._retry) {
       originalRequest._retry = true;
       try {
-        // reissue 요청 시에는 rawAxios를 사용해, api.interceptor에 붙은 Authorization 헤더가 포함되지 않도록 한다.
         const rawAxios = axios.create({
           baseURL: "http://localhost:8080",
           headers: { "Content-Type": "application/json" },
           withCredentials: true,
         });
+
         const refreshRes = await rawAxios.post("/api/reissue");
+
+        if (refreshRes.status !== 200) {
+          localStorage.removeItem("accessToken");
+          window.location.href = "/login";
+          return Promise.reject(refreshRes);
+        }
+
         const newToken = refreshRes.data.data.accessToken;
         localStorage.setItem("accessToken", newToken);
+
         api.defaults.headers.Authorization = `Bearer ${newToken}`;
         originalRequest.headers.Authorization = `Bearer ${newToken}`;
+
         return api(originalRequest);
       } catch (refreshErr) {
         localStorage.removeItem("accessToken");
+        window.location.href = "/login";
         return Promise.reject(refreshErr);
       }
     }
+
     return Promise.reject(error);
   }
 );

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,21 +1,47 @@
+// src/api/api.js
 import axios from "axios";
 
 const api = axios.create({
   baseURL: "http://localhost:8080",
-  headers: {
-    "Content-Type": "application/json",
-  },
+  headers: { "Content-Type": "application/json" },
+  withCredentials: true,
 });
 
 api.interceptors.request.use(
   (config) => {
     const token = localStorage.getItem("accessToken");
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
+    if (token) config.headers.Authorization = `Bearer ${token}`;
     return config;
   },
   (error) => Promise.reject(error)
+);
+
+api.interceptors.response.use(
+  (res) => res,
+  async (error) => {
+    const originalRequest = error.config;
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+      try {
+        // reissue 요청 시에는 rawAxios를 사용해, api.interceptor에 붙은 Authorization 헤더가 포함되지 않도록 한다.
+        const rawAxios = axios.create({
+          baseURL: "http://localhost:8080",
+          headers: { "Content-Type": "application/json" },
+          withCredentials: true,
+        });
+        const refreshRes = await rawAxios.post("/api/reissue");
+        const newToken = refreshRes.data.data.accessToken;
+        localStorage.setItem("accessToken", newToken);
+        api.defaults.headers.Authorization = `Bearer ${newToken}`;
+        originalRequest.headers.Authorization = `Bearer ${newToken}`;
+        return api(originalRequest);
+      } catch (refreshErr) {
+        localStorage.removeItem("accessToken");
+        return Promise.reject(refreshErr);
+      }
+    }
+    return Promise.reject(error);
+  }
 );
 
 export default api;

--- a/src/api/member.js
+++ b/src/api/member.js
@@ -1,6 +1,6 @@
 import api from "./api";
 
-export const getMembers = () => api.get("/members");
+export const getMembers = (params) => api.get("/api/member", { params });
 export const getMemberById = (id) => api.get(`/members/${id}`);
 export const createMember = (data) => api.post("/members", data);
 export const updateMember = (id, data) => api.put(`/members/${id}`, data);

--- a/src/components/layouts/pageWrapper/PageWrapper.jsx
+++ b/src/components/layouts/pageWrapper/PageWrapper.jsx
@@ -7,7 +7,7 @@ export default function PageWrapper({ children }) {
       sx={{
         display: "flex",
         flexDirection: "column",
-        height: "100vh",
+        height: "96vh",
         backgroundColor: (theme) => theme.palette.background.default,
         overflow: "hidden",
         borderRadius: 2,

--- a/src/features/auth/authSlice.js
+++ b/src/features/auth/authSlice.js
@@ -1,14 +1,11 @@
-// src/features/auth/authSlice.js
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import * as authAPI from "@/api/auth";
 
-// Thunks
 export const login = createAsyncThunk(
   "auth/login",
   async (credentials, thunkAPI) => {
     try {
       const response = await authAPI.login(credentials);
-      console.log('response', response.data.data)
       return response.data.data;
     } catch (error) {
       return thunkAPI.rejectWithValue(error.response?.data || "Login failed");
@@ -21,8 +18,7 @@ export const reissueToken = createAsyncThunk(
   async (_, thunkAPI) => {
     try {
       const response = await authAPI.reissueToken();
-      // response.data: { accessToken, expiresAt, ... }
-      return response.data;
+      return response.data.data;
     } catch (error) {
       return thunkAPI.rejectWithValue(error.response?.data || "Reissue failed");
     }
@@ -41,7 +37,6 @@ export const logout = createAsyncThunk(
   }
 );
 
-// 초기 상태를 localStorage에서 복원
 const storedToken = localStorage.getItem("accessToken");
 const storedExpiresAt = localStorage.getItem("expiresAt");
 const storedUserJson = localStorage.getItem("user");
@@ -50,21 +45,19 @@ const initialUser = storedUserJson ? JSON.parse(storedUserJson) : null;
 const authSlice = createSlice({
   name: "auth",
   initialState: {
-    user: initialUser,                // { id, name, role } or null
-    accessToken: storedToken || null, // 복원된 토큰
+    user: initialUser,                
+    accessToken: storedToken || null, 
     expiresAt: storedExpiresAt || null,
     status: "idle",
     error: null,
   },
   reducers: {
     clearAuthState(state) {
-      // Redux state 초기화
       state.user = null;
       state.accessToken = null;
       state.expiresAt = null;
       state.status = "idle";
       state.error = null;
-      // localStorage에서 모두 제거
       localStorage.removeItem("accessToken");
       localStorage.removeItem("expiresAt");
       localStorage.removeItem("user");
@@ -75,24 +68,23 @@ const authSlice = createSlice({
       // === LOGIN ===
       .addCase(login.pending, (state) => {
         state.status = "loading";
-        state.error = null;
+        state.error  = null;
       })
       .addCase(login.fulfilled, (state, action) => {
-        state.status = "succeeded";
+        state.status      = "succeeded";
         state.accessToken = action.payload.accessToken;
-        state.expiresAt = action.payload.expiresAt;
+        state.expiresAt   = action.payload.expiresAt;
         state.user = {
-          id: action.payload.memberId,
+          id:   action.payload.memberId,
           name: action.payload.memberName,
           role: action.payload.memberRole,
         };
-        // localStorage에 저장
         localStorage.setItem("accessToken", action.payload.accessToken);
-        localStorage.setItem("expiresAt", action.payload.expiresAt);
+        localStorage.setItem("expiresAt",   action.payload.expiresAt);
         localStorage.setItem(
           "user",
           JSON.stringify({
-            id: action.payload.memberId,
+            id:   action.payload.memberId,
             name: action.payload.memberName,
             role: action.payload.memberRole,
           })
@@ -100,45 +92,43 @@ const authSlice = createSlice({
       })
       .addCase(login.rejected, (state, action) => {
         state.status = "failed";
-        state.error = action.payload;
+        state.error  = action.payload;
       })
 
       // === REISSUE TOKEN ===
       .addCase(reissueToken.pending, (state) => {
         state.status = "loading";
-        state.error = null;
+        state.error  = null;
       })
       .addCase(reissueToken.fulfilled, (state, action) => {
         state.accessToken = action.payload.accessToken;
-        state.expiresAt = action.payload.expiresAt;
-        state.status = "succeeded";
-        // localStorage 업데이트
+        state.expiresAt   = action.payload.expiresAt;
+        state.status      = "succeeded";
         localStorage.setItem("accessToken", action.payload.accessToken);
-        localStorage.setItem("expiresAt", action.payload.expiresAt);
+        localStorage.setItem("expiresAt",   action.payload.expiresAt);
       })
       .addCase(reissueToken.rejected, (state, action) => {
         state.status = "failed";
-        state.error = action.payload;
+        state.error  = action.payload;
       })
 
       // === LOGOUT ===
       .addCase(logout.pending, (state) => {
         state.status = "loading";
-        state.error = null;
+        state.error  = null;
       })
       .addCase(logout.fulfilled, (state) => {
-        state.status = "idle";
-        state.user = null;
+        state.status      = "idle";
+        state.user        = null;
         state.accessToken = null;
-        state.expiresAt = null;
-        // localStorage 제거
+        state.expiresAt   = null;
         localStorage.removeItem("accessToken");
         localStorage.removeItem("expiresAt");
         localStorage.removeItem("user");
       })
       .addCase(logout.rejected, (state, action) => {
         state.status = "failed";
-        state.error = action.payload;
+        state.error  = action.payload;
       });
   },
 });

--- a/src/features/auth/pages/LoginPage.jsx
+++ b/src/features/auth/pages/LoginPage.jsx
@@ -44,7 +44,6 @@ export default function LoginPage() {
 
     const result = await dispatch(login(form));
     if (login.fulfilled.match(result)) {
-        console.log('result', result)
       const { memberRole, memberId } = result.payload;
       if (memberRole === "ROLE_SYSTEM_ADMIN") {
         navigate("/projects");
@@ -76,9 +75,7 @@ export default function LoginPage() {
         setSnackbarOpen(true);
       }
     } else {
-      // 로그인 실패(잘못된 이메일/비밀번호 등)
       console.error("로그인 실패:", result.payload || result.error);
-      // error 상태가 Redux에 저장되어 있으므로 화면에 메시지가 이미 표시됨
     }
   };
 

--- a/src/features/member/components/MemberTable.jsx
+++ b/src/features/member/components/MemberTable.jsx
@@ -1,0 +1,85 @@
+import CustomTable from "@/components/common/customTable/CustomTable";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchMembers } from "@/features/member/memberSlice";
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+
+const columns = [
+  { key: "avatar", label: "이름", type: "avatar" },
+  { key: "email", label: "이메일", type: "text"},
+  { key: "position", label: "직책", type: "text" },
+  { key: "department", label: "부서", type: "text" },
+  { key: "phoneNumber", label: "연락처", type: "text" },
+  {
+    key: "deleted",
+    label: "상태",
+    type: "status",
+    filter: true,
+    statusMap: {
+      true: { color: "error", label: "비활성" },
+      false: { color: "success", label: "활성" },
+    },
+  },
+  { key: "createdAt", label: "등록일", type: "date" },
+];
+
+export default function MemberTable() {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  const { list: members, totalCount, status, error } = useSelector(
+    (state) => state.member
+  );
+
+  const [page, setPage] = useState(1);
+  const [keywordType, setKeywordType] = useState("");
+  const [keyword, setKeyword] = useState("");
+
+  const loadMembers = useCallback(() => {
+    dispatch(
+      fetchMembers({
+        page,
+        keyword: null,
+        keywordType: null,
+      })
+    );
+  }, [dispatch, page, keywordType, keyword]);
+
+  useEffect(() => {
+    loadMembers();
+  }, [loadMembers]);
+
+  const drawMember = (members || [] ).map((p, idx)=> ({
+    ...p,
+    avatar: {
+        name: p.name,
+        src: `https://i.pravatar.cc/40?u=${p.id}`,
+    }
+  }));
+  return (
+    <CustomTable
+      columns={columns}
+      rows={drawMember || []}
+      onRowClick={(row) => {
+        navigate(`/members/${row.id}`);
+      }}
+      pagination={{
+        page,
+        size: 10,
+        total: totalCount || 0,
+        onPageChange: (newPage) => setPage(newPage),
+      }}
+      search={{
+        key: "name",
+        placeholder: "이름을 검색하세요",
+        value: keyword,
+        onChange: (newValue) => {
+          setPage(1);
+          setKeyword(newValue);
+        },
+      }}
+      loading={status === "loading"}
+      error={error}
+    />
+  );
+} 

--- a/src/features/member/memberSlice.js
+++ b/src/features/member/memberSlice.js
@@ -3,10 +3,17 @@ import * as memberAPI from "@/api/member";
 
 export const fetchMembers = createAsyncThunk(
   "member/fetchMembers",
-  async (_, thunkAPI) => {
+  async ({ page, keyword, keywordType }, thunkAPI) => {
     try {
-      const response = await memberAPI.getMembers();
-      return response.data;
+
+     const params = {};
+     params.page = page;
+     if (keyword) params.keyword = keyword;
+     if (keywordType) params.keywordType = keywordType;
+
+
+      const response = await memberAPI.getMembers(params);
+      return response.data.data;
     } catch (error) {
       return thunkAPI.rejectWithValue(error.response?.data || "Error");
     }
@@ -16,8 +23,11 @@ export const fetchMembers = createAsyncThunk(
 const memberSlice = createSlice({
   name: "member",
   initialState: {
-    data: [],
+    list: [],
     current: null,
+    loading: false,
+    error: null,
+    totalCount: 0,
   },
   reducers: {
     clearCurrentMember(state) {
@@ -25,8 +35,17 @@ const memberSlice = createSlice({
     },
   },
   extraReducers: (builder) => {
-    builder.addCase(fetchMembers.fulfilled, (state, action) => {
-      state.data = action.payload;
+    builder.addCase(fetchMembers.pending, (state) => {
+      state.loading = true;
+      state.error = null;
+    })
+    .addCase(fetchMembers.fulfilled, (state, action) => {
+      state.list = action.payload.members;
+      state.totalCount = action.payload.totalCount;
+    })
+    .addCase(fetchMembers.rejected, (state, action) => {
+      state.loading = false;
+      state.error = action.payload;
     });
   },
 });

--- a/src/features/member/pages/MemberPage.jsx
+++ b/src/features/member/pages/MemberPage.jsx
@@ -1,0 +1,44 @@
+// src/features/project/pages/ProjectPage.jsx
+import { useSelector } from "react-redux";
+import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
+import PageHeader from "@/components/layouts/pageHeader/PageHeader";
+import MemberTable from "@/features/member/components/MemberTable";
+import CustomButton from "@/components/common/customButton/CustomButton";
+import { useNavigate } from "react-router-dom";
+import { Add } from "@mui/icons-material";
+import { Box } from "@mui/material";
+
+export default function ProjectPage() {
+  const navigate = useNavigate();
+
+  const { totalCount } = useSelector((state) => state.project);
+
+  return (
+    <PageWrapper>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          borderRadius: 2,
+        }}
+      >
+        <PageHeader
+          title="회원"
+          subtitle={`총 ${totalCount ?? 0}개의 회원이 있습니다.`}
+          action={
+            <CustomButton
+              startIcon={<Add />}
+              onClick={() => navigate("/members/new")}
+            >
+              회원 생성
+            </CustomButton>
+          }
+        />
+        <Box sx={{ flex: 1, overflow: "hidden", mb: 3 }}>
+          <MemberTable />
+        </Box>
+      </Box>
+    </PageWrapper>
+  );
+}

--- a/src/features/project/components/ProjectTable.jsx
+++ b/src/features/project/components/ProjectTable.jsx
@@ -13,9 +13,9 @@ const columns = [
     type: "status",
     filter: true,
     statusMap: {
-      deleted: { key: "warning", label: "비활성됨" },
-      디자인: { key: "success", label: "디자인" },
-      개발: { key: "error", label: "개발" },
+      deleted: { color: "warning", label: "비활성됨" },
+      디자인: { color: "success", label: "디자인" },
+      개발: { color: "error", label: "개발" },
     },
   },
   { key: "progress", label: "진행도", type: "progress" },

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -1,6 +1,7 @@
 // src/components/layout/Sidebar.jsx
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useLocation } from "react-router-dom";
+import { useDispatch } from "react-redux";
 import {
   Box,
   ListItemButton,
@@ -9,6 +10,8 @@ import {
   Typography,
   Avatar,
 } from "@mui/material";
+import ExitToAppIcon from "@mui/icons-material/ExitToApp";
+
 import {
   SidebarRoot,
   ProfileSection,
@@ -17,8 +20,13 @@ import {
 } from "./Sidebar.styles";
 import navItems from "../../constants/navItems";
 
+import { logout as logoutThunk, clearAuthState } from "@/features/auth/authSlice";
+
 export default function Sidebar({ onClose }) {
   const navigate = useNavigate();
+  const location = useLocation();
+  const dispatch = useDispatch();
+
   const currentPath = location.pathname;
 
   const handleItemClick = (path) => {
@@ -26,18 +34,32 @@ export default function Sidebar({ onClose }) {
     navigate(path);
   };
 
+  const handleLogout = async () => {
+    try {
+      await dispatch(logoutThunk()).unwrap();
+
+      dispatch(clearAuthState());
+
+      onClose();
+      navigate("/login");
+    } catch (err) {
+      console.error("로그아웃 실패:", err);
+    }
+  };
+
   return (
     <SidebarRoot>
-      {/* User Profile */}
+      {/* 1. User Profile */}
       <ProfileSection>
         <Avatar src="/toss_logo.png" />
-        <div className="profile-text">
-          <span className="profile-role">개발자</span>
-          <span className="profile-name">이수하</span>
+        <div className="profile-text" style={{ marginLeft: 8 }}>
+          <Typography variant="body2">
+            개발자
+          </Typography>
+          <Typography variant="subtitle1">이수하</Typography>
         </div>
       </ProfileSection>
 
-      {/* Navigation */}
       <NavList>
         {navItems.map(({ text, icon: Icon, path }) => (
           <NavItem
@@ -54,6 +76,20 @@ export default function Sidebar({ onClose }) {
           </NavItem>
         ))}
       </NavList>
+
+      <Box sx={{ mt: "auto" }}>
+        <NavItem onClick={handleLogout} disablePadding>
+          <ListItemButton>
+            <ListItemIcon>
+              <ExitToAppIcon sx={{ color: "background.default" }} />
+            </ListItemIcon>
+            <ListItemText
+              primary="로그아웃"
+              primaryTypographyProps={{ color: "background.default" }}
+            />
+          </ListItemButton>
+        </NavItem>
+      </Box>
     </SidebarRoot>
   );
 }

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -6,6 +6,7 @@ import ProjectFormPage from "@/features/project/pages/ProjectFormPage";
 import MainLayout from "@/layouts/MainLayout";
 import LoginPage from "@/features/auth/pages/LoginPage";
 import { useSelector } from "react-redux";
+import MemberPage from "@/features/member/pages/MemberPage";
 
 export default function MainRoutes() {
   // const isAuthenticated = useSelector((state) => state.auth.isAuthenticated) || false; // 예시: 로그인 상태 Redux에서 가져옴
@@ -31,6 +32,7 @@ export default function MainRoutes() {
         <Route path="/projects/:id" element={<ProjectDetailPage />} />
         <Route path="/projects/new" element={<ProjectFormPage />} />
         <Route path="/projects/:id/edit" element={<ProjectFormPage />} />
+        <Route path="/members" element={<MemberPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
## 📌 개요

* Axios 응답 인터셉터에 토큰 재발급 실패 시 로그인 페이지로 자동 리디렉션하는 기능을 추가했습니다.
* 이를 통해 액세스 토큰 재발급 과정에서 실패가 발생하면 사용자 세션을 초기화하고 즉시 로그인 화면으로 이동하도록 구현했습니다.

## 🛠️ 변경 사항

* 응답 인터셉터에 401 에러 감지 로직 추가

  * `originalRequest._retry` 플래그를 사용하여 재발급 요청이 중복되지 않도록 처리
* `rawAxios` 인스턴스를 새로 생성하여 `/api/reissue` 호출

  * 재발급 응답 상태가 200이 아닌 경우 또는 재발급 자체가 실패하면

    * `localStorage`의 `accessToken` 제거
    * `window.location.href = "/login"`으로 강제 이동
* 재발급 성공 시

  * 새로 받아온 `accessToken`을 `localStorage`, `api.defaults.headers.Authorization`, `originalRequest.headers.Authorization`에 반영
  * 원래의 요청(`originalRequest`)을 새로운 토큰으로 재시도

## ✅ 주요 체크 포인트

* [ ] 401 에러 발생 시 `rawAxios.post("/api/reissue")`가 정상 호출되는지 확인
* [ ] 재발급 응답이 200이 아닌 경우 `accessToken`이 제거되고 `/login` 경로로 이동하는지 검증
* [ ] 재발급 성공 시 기존 요청이 새로운 토큰으로 재시도되는지 확인
* [ ] `originalRequest._retry` 플래그가 중복 호출을 방지하도록 올바르게 설정되었는지 검토
* [ ] 네트워크 오류나 서버 오류(403, 500 등) 발생 시에도 동일하게 리디렉션되는지 테스트

## 🔁 테스트 결과

1. **재발급 실패 시 시나리오**

   * 보호 API 호출 → 응답 401
   * `/api/reissue` 호출 결과가 400 또는 500 응답
   * `localStorage.removeItem("accessToken")` 실행
   * 브라우저가 `/login` 페이지로 즉시 이동

2. **재발급 성공 시 시나리오**

   * 보호 API 호출 → 응답 401
   * `/api/reissue` 호출 결과 200, 새로운 `accessToken` 반환
   * `localStorage`에 새 토큰 저장
   * 원래 요청(`originalRequest`)이 새로운 토큰으로 재시도되어 정상 응답 수신

3. **네트워크 오류 처리**

   * `/api/reissue` 호출 도중 네트워크 에러 발생
   * `accessToken` 제거 후 `/login`으로 리디렉션됨

## 🔗 연관된 이슈

* 없음

## 📑 레퍼런스

* [[Axios Response Interceptors 공식 문서](https://axios-http.com/docs/interceptors)](https://axios-http.com/docs/interceptors)
* [[JWT 토큰 재발급 패턴](https://jwt.io/introduction)](https://jwt.io/introduction)