### PR TITLE
feat: 권한 기반 사이드바 메뉴 렌더링 및 사용자 정보 노출(#45)

### DIFF
--- a/constants/navItems.js
+++ b/constants/navItems.js
@@ -6,11 +6,36 @@ import FolderRoundedIcon from "@mui/icons-material/FolderRounded";
 import HistoryRoundedIcon from "@mui/icons-material/HistoryRounded";
 
 const navItems = [
-  { text: "개발사 관리", icon: DeveloperModeRoundedIcon, path: "/companies" },
-  { text: "고객사 관리", icon: BusinessRoundedIcon, path: "/clients" },
-  { text: "회원 관리", icon: PersonIcon, path: "/members" },
-  { text: "프로젝트 관리", icon: FolderRoundedIcon, path: "/projects" },
-  { text: "로그", icon: HistoryRoundedIcon, path: "/logs" },
+  {
+    text: "개발사 관리",
+    icon: DeveloperModeRoundedIcon,
+    path: "/companies",
+    roles: ["ROLE_SYSTEM_ADMIN"],
+  },
+  {
+    text: "고객사 관리",
+    icon: BusinessRoundedIcon,
+    path: "/clients",
+    roles: ["ROLE_SYSTEM_ADMIN"],
+  },
+  {
+    text: "회원 관리",
+    icon: PersonIcon,
+    path: "/members",
+    roles: ["ROLE_SYSTEM_ADMIN", "ROLE_DEV_ADMIN", "ROLE_CLIENT_ADMIN"],
+  },
+  {
+    text: "프로젝트 관리",
+    icon: FolderRoundedIcon,
+    path: "/projects",
+    roles: ["ROLE_SYSTEM_ADMIN", "ROLE_DEV_ADMIN", "ROLE_CLIENT_ADMIN", "ROLE_USER"],
+  },
+  {
+    text: "로그",
+    icon: HistoryRoundedIcon,
+    path: "/logs",
+    roles: ["ROLE_SYSTEM_ADMIN"],
+  },
 ];
 
 export default navItems;

--- a/src/features/auth/authSlice.js
+++ b/src/features/auth/authSlice.js
@@ -101,11 +101,25 @@ const authSlice = createSlice({
         state.error  = null;
       })
       .addCase(reissueToken.fulfilled, (state, action) => {
+        state.status      = "succeeded";
         state.accessToken = action.payload.accessToken;
         state.expiresAt   = action.payload.expiresAt;
-        state.status      = "succeeded";
+        state.user = {
+          id:   action.payload.memberId,
+          name: action.payload.memberName,
+          role: action.payload.memberRole,
+        };
         localStorage.setItem("accessToken", action.payload.accessToken);
         localStorage.setItem("expiresAt",   action.payload.expiresAt);
+        localStorage.setItem(
+          "user",
+          JSON.stringify({
+            id:   action.payload.memberId,
+            name: action.payload.memberName,
+            role: action.payload.memberRole,
+          })
+        );
+        
       })
       .addCase(reissueToken.rejected, (state, action) => {
         state.status = "failed";

--- a/src/utils/roleUtils.js
+++ b/src/utils/roleUtils.js
@@ -1,0 +1,14 @@
+export function getRoleLabel(role) {
+  switch (role) {
+    case "ROLE_SYSTEM_ADMIN":
+      return "시스템 관리자";
+    case "ROLE_DEV_ADMIN":
+      return "ROLE개발 관리자";
+    case "ROLE_CLIENT_ADMIN":
+      return "고객사 관리자";
+    case "ROLE_SER":
+      return "사용자";
+    default:
+      return "권한 없음";
+  }
+}


### PR DESCRIPTION
## 📌 개요

* Redux `auth` 상태로부터 로그인된 사용자의 `memberName`과 `memberRole`을 가져와 사이드바 상단에 표시하고, 각 메뉴 항목에 허용된 권한(`roles`)을 정의하여 로그인된 사용자의 권한에 맞게 사이드바 메뉴를 필터링하여 렌더링하도록 구현했습니다.

---

## 🛠️ 변경 사항

* **Redux `auth` 상태 참조**

  * 사이드바 컴포넌트에서 `state.auth.user.name`(`memberName`)과 `state.auth.user.role`(`memberRole`)을 가져와 프로필 영역에 노출
* **`navItems` 데이터 구조 확장**

  * 기존 `{ text, icon, path }` 구조에 각 메뉴별 허용 권한(`roles: ['SYSTEM_ADMIN', 'DEV_ADMIN', ...]`) 속성 추가
* **권한 기반 메뉴 렌더링 로직**

  * 로그인된 사용자의 `memberRole`을 기준으로, 해당 권한이 포함된 메뉴 항목만 필터링하여 렌더링
  * 필터링된 결과로 `NavList`에 노출될 메뉴 리스트 생성
* **권한 검사 및 예외 처리**

  * 사용자의 권한(`memberRole`)이 없거나 예상치 못한 값일 경우 `window.alert`로 경고 메시지를 띄우고, Redux `clearAuthState()` 호출 후 `/login`으로 리다이렉트
* **상태 복원 및 로그아웃 처리**

  * 페이지 새로고침 시 로컬 스토리지에 저장된 `accessToken`을 통해 Redux `auth` 상태를 복원하여 권한 정보가 유지되도록 구현
  * 로그아웃 시 Redux 상태 및 로컬 스토리지에서 사용자 관련 정보(`accessToken`, `user`)를 모두 제거하여, 로그아웃 직후 사이드바에 메뉴가 보이지 않도록 함

---

## ✅ 주요 체크 포인트

* [ ] **프로필 정보 출력**

  * 로그인 시 `state.auth.user.name`과 `state.auth.user.role` 값이 정상적으로 사이드바 상단에 표시되는지 확인
* [ ] **권한 기반 메뉴 필터링**

  * `SYSTEM_ADMIN`, `DEV_ADMIN`, `CLIENT_ADMIN`, `USER` 등 각 역할(role)에 따라 `navItems` 중 허용된 메뉴만 노출되는지 검증
  * 허용되지 않은 메뉴가 화면에 렌더링되지 않는지 확인
* [ ] **예외 처리**

  * 로컬 스토리지에 `accessToken`이나 사용자 정보가 없는 상태로 접근 시, 경고창(`window.alert`)이 뜨며 `/login`으로 리다이렉트되는지 확인
* [ ] **페이지 새로고침 후 상태 복원**

  * 페이지 새로고침 시 로컬 스토리지에 남아있는 `accessToken`으로 Redux `auth` 상태가 올바르게 복원되고, 권한에 맞는 메뉴가 노출되는지 테스트
* [ ] **로그아웃 기능 연동**

  * “로그아웃” 버튼 클릭 시 `logoutThunk()`이 정상 호출되어 로컬 스토리지와 Redux `auth` 상태가 모두 초기화되고, 로그인 화면으로 이동되는지 확인

---

## 🔁 테스트 결과

* **권한별 사이드바 메뉴 노출 테스트**

  1. `SYSTEM_ADMIN` 계정으로 로그인 → `개발사 관리`, `고객사 관리`, `회원 관리`, `프로젝트 관리`, `로그` 등 전체 메뉴가 정상 노출
  2. `DEV_ADMIN` 계정으로 로그인 → `개발사 관리`, `프로젝트 관리`만 노출
  3. `CLIENT_ADMIN` 계정으로 로그인 → `고객사 관리`, `프로젝트 관리`만 노출
  4. `USER` 계정으로 로그인 → `프로젝트 관리`(이름만)만 노출

* **권한 없이 접근 시 예외 처리**

  * 로컬 스토리지에서 `accessToken`을 삭제한 후 새로고침 → 경고창 팝업 후 `/login`으로 리다이렉트됨

* **페이지 새로고침 후 상태 유지 테스트**

  * 로그인 후 페이지 새로고침 → 토큰이 유효하면 Redux `auth` 상태가 복원되어, 권한에 맞는 메뉴가 계속 노출됨

* **로그아웃 기능 테스트**

  * “로그아웃” 버튼 클릭 → `logoutThunk()`로 백엔드 호출, Redux `auth` 상태 및 로컬 스토리지 초기화, `/login` 페이지로 이동

---

## 🔗 연관된 이슈

- #45

---

## 📑 레퍼런스

* [React Redux 공식문서 – `useSelector` 사용법](https://react-redux.js.org/api/hooks#useselector)
* [[React Router v6 – 보호된 라우트 예시](https://reactrouter.com/docs/en/v6/examples/auth)](https://reactrouter.com/docs/en/v6/examples/auth)
* [[Material-UI – Drawer/Sidebar 컴포넌트](https://mui.com/components/drawers/)](https://mui.com/components/drawers/)