### PR TITLE
[feat]ProjectDetailPage 레이아웃 및 스크롤 개선(#34)

### DIFF
--- a/constants/navItems.js
+++ b/constants/navItems.js
@@ -6,11 +6,36 @@ import FolderRoundedIcon from "@mui/icons-material/FolderRounded";
 import HistoryRoundedIcon from "@mui/icons-material/HistoryRounded";
 
 const navItems = [
-  { text: "개발사 관리", icon: DeveloperModeRoundedIcon, path: "/companies" },
-  { text: "고객사 관리", icon: BusinessRoundedIcon, path: "/clients" },
-  { text: "회원 관리", icon: PersonIcon, path: "/members" },
-  { text: "프로젝트 관리", icon: FolderRoundedIcon, path: "/projects" },
-  { text: "로그", icon: HistoryRoundedIcon, path: "/logs" },
+  {
+    text: "개발사 관리",
+    icon: DeveloperModeRoundedIcon,
+    path: "/companies",
+    roles: ["ROLE_SYSTEM_ADMIN"],
+  },
+  {
+    text: "고객사 관리",
+    icon: BusinessRoundedIcon,
+    path: "/clients",
+    roles: ["ROLE_SYSTEM_ADMIN"],
+  },
+  {
+    text: "회원 관리",
+    icon: PersonIcon,
+    path: "/members",
+    roles: ["ROLE_SYSTEM_ADMIN", "ROLE_DEV_ADMIN", "ROLE_CLIENT_ADMIN"],
+  },
+  {
+    text: "프로젝트 관리",
+    icon: FolderRoundedIcon,
+    path: "/projects",
+    roles: ["ROLE_SYSTEM_ADMIN", "ROLE_DEV_ADMIN", "ROLE_CLIENT_ADMIN", "ROLE_USER"],
+  },
+  {
+    text: "로그",
+    icon: HistoryRoundedIcon,
+    path: "/logs",
+    roles: ["ROLE_SYSTEM_ADMIN"],
+  },
 ];
 
 export default navItems;

--- a/src/components/common/customTable/CustomTable.jsx
+++ b/src/components/common/customTable/CustomTable.jsx
@@ -86,7 +86,6 @@ export default function CustomTable({
   return (
     <Box
       sx={{
-        // backgroundColor: theme.palette.background.default,
         flexGrow: 1,
         px: 3,
         pb: 3,
@@ -154,16 +153,15 @@ export default function CustomTable({
           </Box>
         )}
 
-        {/* 가로 스크롤 영역 */}
-        <Box sx={{ flex: 1, overflow: "auto" }}>
+        <Box sx={{ flex: 1, overflow: "auto"}}>
           <Box
             sx={{
-              height: "100%",
-              overflow: "auto",
+              height: "66vh",
               "&::-webkit-scrollbar": { width: 6 },
               "&::-webkit-scrollbar-thumb": {
                 backgroundColor: theme.palette.grey[300],
-                borderRadius: 4,
+                borderRadius: 2,
+                overflow: "auto"
               },
             }}
           >
@@ -242,11 +240,9 @@ export default function CustomTable({
                   </TableRow>
                 ))}
               </TableBody>
+                 
             </Table>
-          </Box>
-        </Box>
-
-        {pagination && (
+                {pagination && (
           <Box p={2}>
             <Stack direction="row" justifyContent="flex-end">
               <Pagination
@@ -258,6 +254,9 @@ export default function CustomTable({
             </Stack>
           </Box>
         )}
+          </Box>
+   
+        </Box>
       </Paper>
     </Box>
   );

--- a/src/components/common/sectionTable/SectionTable.jsx
+++ b/src/components/common/sectionTable/SectionTable.jsx
@@ -9,6 +9,7 @@ import {
   TableRow,
   Stack,
   TableSortLabel,
+  Box
 } from "@mui/material";
 import CustomButton from "@/components/common/customButton/CustomButton";
 
@@ -59,7 +60,7 @@ export default function SectionTable({
   }, [rows, sortConfig]);
 
   return (
-    <>
+    <Box sx={{width: "100%"}}>
       {phases && onPhaseChange && (
         <Stack direction="row" spacing={1} mb={2}>
           {phases.map((phase) => (
@@ -131,6 +132,6 @@ export default function SectionTable({
           </TableBody>
         </Table>
       </TableContainer>
-    </>
+    </Box>
   );
 }

--- a/src/components/layouts/tabsWithContent/TabsWithContent.jsx
+++ b/src/components/layouts/tabsWithContent/TabsWithContent.jsx
@@ -1,7 +1,8 @@
-import { Paper, Tabs, Tab, Box, Typography, Stack } from "@mui/material";
+// src/components/layouts/tabsWithContent/TabsWithContent.jsx
+import { Paper, Tabs, Tab, Box, Typography } from "@mui/material";
 
 export default function TabsWithContent({
-  tabs = [], // [{ label: "탭이름", icon: <Icon /> }]
+  tabs = [],
   value,
   onChange,
   tabSx = {},
@@ -13,20 +14,19 @@ export default function TabsWithContent({
     <Paper
       elevation={0}
       sx={{
-        backgroundColor: "background.paper",
-        flexGrow: 1,
-        mx: 3,
-        mb: 3,
-        px: 3,
-        pb: 3,
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",       // 부모로부터 내려온 높이를 100%로 채움
+        minHeight: 0,         // 자식이 넘칠 때 스크롤을 위해 반드시 필요
         borderRadius: 3,
         border: "1px solid",
         borderColor: "divider",
-        display: "flex",
-        flexDirection: "column",
+        overflow: "hidden",
+        px:3,
         ...containerSx,
       }}
     >
+      {/* ─── 1. 탭바 (고정 높이) ───────────────── */}
       <Tabs
         value={value}
         onChange={onChange}
@@ -46,14 +46,45 @@ export default function TabsWithContent({
             icon={tab.icon}
             iconPosition="start"
             label={tab.label}
+            sx={{
+              textTransform: "none",
+              fontWeight: "500",
+              px: 2,
+              color: "text.primary",
+              "&.Mui-selected": {
+                color: "primary.main",
+                fontWeight: "600",
+              },
+              ...(tab.sx ?? {}),
+            }}
           />
         ))}
       </Tabs>
 
-      <Box flexGrow={1} pt={3} sx={{ ...contentSx }}>
-        {content || (
-          <Typography color="text.secondary">내용이 없습니다</Typography>
-        )}
+      {/* ─── 2. 콘텐츠 영역 (스크롤 가능) ───────────────── */}
+      <Box
+        sx={{
+          flexGrow: 1,
+          minHeight: 0,          // 매우 중요: 이걸 주어야 flexGrow 영역이 스크롤을 갖는다
+          width: "100%",         // 가로 너비를 항상 100%로 채워서 탭마다 크기 변동을 없앤다
+          overflowY: "auto",     // 내용이 넘칠 때 내부에서만 스크롤
+          ...contentSx,
+        }}
+      >
+        {/* 
+          콘텐츠 컴포넌트를 감싸서, 
+          내부에서 스크롤이 잘 동작하려면 이 Box를 통해 크기를 100%로 고정해야 한다 
+        */}
+        <Box
+          sx={{
+            width: "100%",   // 자식 콘텐츠가 부모 가로 폭을 완전히 채움
+            minHeight: 0,    // 이걸 달아야 세로 스크롤이 올바르게 동작함
+          }}
+        >
+          {content || (
+            <Typography color="text.secondary">내용이 없습니다</Typography>
+          )}
+        </Box>
       </Box>
     </Paper>
   );

--- a/src/features/auth/authSlice.js
+++ b/src/features/auth/authSlice.js
@@ -101,11 +101,25 @@ const authSlice = createSlice({
         state.error  = null;
       })
       .addCase(reissueToken.fulfilled, (state, action) => {
+        state.status      = "succeeded";
         state.accessToken = action.payload.accessToken;
         state.expiresAt   = action.payload.expiresAt;
-        state.status      = "succeeded";
+        state.user = {
+          id:   action.payload.memberId,
+          name: action.payload.memberName,
+          role: action.payload.memberRole,
+        };
         localStorage.setItem("accessToken", action.payload.accessToken);
         localStorage.setItem("expiresAt",   action.payload.expiresAt);
+        localStorage.setItem(
+          "user",
+          JSON.stringify({
+            id:   action.payload.memberId,
+            name: action.payload.memberName,
+            role: action.payload.memberRole,
+          })
+        );
+        
       })
       .addCase(reissueToken.rejected, (state, action) => {
         state.status = "failed";

--- a/src/features/project/components/PostTable.jsx
+++ b/src/features/project/components/PostTable.jsx
@@ -1,6 +1,6 @@
 // src/components/common/postTable/PostTable.jsx
 import React, { useState, useMemo } from "react";
-import { LinearProgress, Stack, Typography, Chip } from "@mui/material";
+import { LinearProgress, Stack, Typography, Chip, Box } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import SectionTable from "@/components/common/sectionTable/SectionTable";
 
@@ -42,7 +42,7 @@ export default function PostTable({ rows }) {
     return dataRows.filter((row) => row.status === selectedPhase);
   }, [dataRows, selectedPhase]);
 
-  // "상태" 칩 렌더링 함수: theme.palette.status 구조 활용
+  // "상태" 칩 렌더링 함수
   const getStatusChip = (status) => {
     const map = {
       기획: "warning",
@@ -71,7 +71,7 @@ export default function PostTable({ rows }) {
     );
   };
 
-  // 컬럼 정의: sortable을 true로 설정하면 헤더 클릭 시 정렬 가능
+  // 컬럼 정의
   const columns = [
     {
       key: "title",
@@ -141,13 +141,17 @@ export default function PostTable({ rows }) {
   ];
 
   return (
-    <SectionTable
-      columns={columns}
-      rows={filteredRows}
-      phases={phaseTabs}
-      selectedPhase={selectedPhase}
-      onPhaseChange={setSelectedPhase}
-      rowKey="id"
-    />
+    // 테이블이 부모 폭을 넘지 않도록 감싸는 Box에 width:100%와 overflowX:auto 지정
+    <Box sx={{ width: "100%", overflowX: "auto", }}>
+      <SectionTable
+        columns={columns}
+        rows={filteredRows}
+        phases={phaseTabs}
+        selectedPhase={selectedPhase}
+        onPhaseChange={setSelectedPhase}
+        rowKey="id"
+        sx={{ width: "100%" }} // SectionTable 자체에도 100% 폭을 줘서 부모 폭을 따르게 함
+      />
+    </Box>
   );
 }

--- a/src/features/project/components/ProjectManagement.jsx
+++ b/src/features/project/components/ProjectManagement.jsx
@@ -1,6 +1,5 @@
-
+// src/components/ProjectManagement.jsx
 import React, { useEffect, useState } from "react";
-
 import {
   Box,
   Paper,
@@ -17,7 +16,6 @@ import {
   Tooltip,
   Chip,
   Stack,
-  useTheme,
 } from "@mui/material";
 import { InfoOutlined } from "@mui/icons-material";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
@@ -111,24 +109,14 @@ function StageCard({ id, label, index }) {
   );
 }
 
-/**
- * ProjectManagement 컴포넌트
- * - 1) 프로젝트 단계 설정
- * - 2) 프로젝트 참여자 관리 (직원 리스트 Autocomplete)
- * - 3) 선택된 참여자 목록(칩 형태) + 삭제 버튼
- */
 export default function ProjectManagement({
   initialStages = ["기획", "디자인", "퍼블리싱", "개발", "검수"],
+  initialParticipants = [],
 }) {
-
   const theme = useMuiTheme();
-  const [stages, setStages] = useState(initialStages); // 단계 카드 배열
-
-  // 직원 목록(API에서 받아올 예정)
-  const [allEmployees, setAllEmployees] = useState([]); // { id, name, avatarUrl }
-  // 선택된 참여자(직원) 상태
-  const [selectedEmployees, setSelectedEmployees] = useState([]);
-
+  const [stages, setStages] = useState(initialStages);
+  const [allEmployees, setAllEmployees] = useState([]);
+  const [selectedEmployees, setSelectedEmployees] = useState(initialParticipants);
 
   // DnD 설정
   const sensors = useSensors(useSensor(PointerSensor));
@@ -142,22 +130,13 @@ export default function ProjectManagement({
     }
   };
 
-  // 백엔드에서 직원 목록을 받아오는 예시(fetch)
   useEffect(() => {
     fetch("/api/employees")
       .then((res) => res.json())
-      .then((data) => {
-        // data는 [{ id, name, avatarUrl }, ...] 형식이라고 가정
-        setAllEmployees(data);
-      })
-      .catch((err) => {
-        console.error("직원 목록을 가져오는 중 오류 발생:", err);
-        // 오류 시 기본값 할당
-        setAllEmployees([]);
-      });
+      .then((data) => setAllEmployees(data))
+      .catch(() => setAllEmployees([]));
   }, []);
 
-  // 선택된 직원 리스트에서 삭제
   const handleRemoveEmployee = (empId) => {
     setSelectedEmployees((prev) => prev.filter((emp) => emp.id !== empId));
   };
@@ -165,88 +144,63 @@ export default function ProjectManagement({
   return (
     <Box
       sx={{
-        height: "100%",
         display: "flex",
         flexDirection: "column",
+        height: "100%",
+        minHeight: 0,
+        width: "100%",     // 반드시 부모 폭을 100%로 채움
+        overflow: "hidden",
       }}
     >
-      <Box sx={{ flexShrink: 0 }}>
+      {/* 프로젝트 단계 카드 영역 */}
+      <Box sx={{ my: 2, width: "100%", overflowX: "auto" }}>
         <Stack direction="row" alignItems="center" spacing={1}>
-          <Typography variant="h6" fontWeight={600} sx={{ mb: 0.5 }}>
+          <Typography variant="h6" fontWeight={600}>
             1. 프로젝트 단계 설정
           </Typography>
-          <Tooltip title="  드래그하여 단계를 변경할 수 있습니다.">
+          <Tooltip title="드래그하여 단계를 변경할 수 있습니다.">
             <InfoOutlined fontSize="small" color="action" />
           </Tooltip>
         </Stack>
         <Divider sx={{ mt: 1, mb: 2 }} />
-        <Paper
-          elevation={2}
-          sx={{
-            width: "100%",
-            boxSizing: "border-box",
-            p: 2,
-            maxWidth: "100%",
-            border: "none",
-            boxShadow: "none",
-          }}
-        >
-          <DndContext
-            sensors={sensors}
-            collisionDetection={closestCenter}
-            onDragEnd={handleDragEnd}
-          >
-            <SortableContext
-              items={stages}
-              strategy={horizontalListSortingStrategy}
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={stages} strategy={horizontalListSortingStrategy}>
+            <Box
+              sx={{
+                display: "flex",
+                flexDirection: "row",
+                flexWrap: "nowrap",
+                width: "max-content",
+                boxSizing: "border-box",
+                py: 1,
+              }}
             >
-              <Box
-                sx={{
-                  display: "flex",
-                  flexDirection: "row",
-                  flexWrap: "wrap",
-                  justifyContent: "flex-start",
-                  alignItems: "center",
-                  width: "100%",
-                  boxSizing: "border-box",
-                }}
-              >
-                {stages.map((stage, idx) => (
-                  <StageCard
-                    key={stage}
-                    id={stage}
-                    label={stage}
-                    index={idx}
-                  />
-                ))}
-              </Box>
-            </SortableContext>
-          </DndContext>
-        </Paper>
+              {stages.map((stage, idx) => (
+                <StageCard key={stage} id={stage} label={stage} index={idx} />
+              ))}
+            </Box>
+          </SortableContext>
+        </DndContext>
       </Box>
 
-
-      <Box sx={{ flexShrink: 0 }}>
+      {/* 프로젝트 참여자 관리 */}
+      <Box sx={{ mb: 2, width: "100%" }}>
         <Stack direction="row" alignItems="center" spacing={1}>
-          <Typography variant="h6" fontWeight={600} sx={{ mb: 0.5 }}>
+          <Typography variant="h6" fontWeight={600}>
             2. 프로젝트 참여자 관리
           </Typography>
-          <Tooltip title=" 직원 목록에서 참여 직원을 선택하세요. (다중 선택 가능)">
+          <Tooltip title="직원 목록에서 참여 직원을 선택하세요. (다중 선택 가능)">
             <InfoOutlined fontSize="small" color="action" />
           </Tooltip>
-
         </Stack>
         <Divider sx={{ mt: 1, mb: 2 }} />
-
         <Autocomplete
           multiple
           options={allEmployees}
           disableCloseOnSelect
           getOptionLabel={(option) => option.name}
           value={selectedEmployees}
-          onChange={(event, newValue) => {
-            setSelectedEmployees(newValue);
-          }}
+          onChange={(event, newValue) => setSelectedEmployees(newValue)}
           renderOption={(props, option, { selected }) => (
             <Box
               component="li"
@@ -269,12 +223,7 @@ export default function ProjectManagement({
                 {option.name}
               </Typography>
               {selected && (
-                <Chip
-                  label="선택됨"
-                  size="small"
-                  color="primary"
-                  sx={{ ml: 1 }}
-                />
+                <Chip label="선택됨" size="small" color="primary" sx={{ ml: 1 }} />
               )}
             </Box>
           )}
@@ -314,32 +263,39 @@ export default function ProjectManagement({
           }}
         />
       </Box>
+
+      {/* 선택된 참여자 리스트 */}
       <Box
         sx={{
-          flex: 1,
+          flexGrow: 1,
+          minHeight: 0,
+          width: "100%",
           display: "flex",
           flexDirection: "column",
+          overflow: "hidden",
         }}
       >
         <Paper
           elevation={2}
           sx={{
-            flex: 1,
             p: 1,
             borderRadius: 2,
             bgcolor: theme.palette.background.paper,
+            boxShadow: "none",
+            height: "100%",
+            display: "flex",
+            flexDirection: "column",
             overflow: "hidden",
           }}
         >
           {selectedEmployees.length === 0 ? (
             <Box
               sx={{
-                height: "100%",
+                flexGrow: 1,
                 display: "flex",
                 alignItems: "center",
                 justifyContent: "center",
                 color: theme.palette.text.disabled,
-                boxShadow: "none",
               }}
             >
               아직 선택된 참여자가 없습니다.
@@ -347,7 +303,8 @@ export default function ProjectManagement({
           ) : (
             <Box
               sx={{
-                height: "100%",
+                flexGrow: 1,
+                minHeight: 0,
                 overflowY: "auto",
                 "&::-webkit-scrollbar": { width: 6 },
                 "&::-webkit-scrollbar-thumb": {
@@ -371,11 +328,7 @@ export default function ProjectManagement({
                       </ListItemAvatar>
                       <ListItemText
                         primary={
-                          <Typography
-                            variant="body1"
-                            fontWeight={500}
-                            sx={{ fontSize: 15 }}
-                          >
+                          <Typography variant="body1" fontWeight={500} sx={{ fontSize: 15 }}>
                             {emp.name}
                           </Typography>
                         }

--- a/src/features/project/components/ProjectTable.jsx
+++ b/src/features/project/components/ProjectTable.jsx
@@ -46,7 +46,6 @@ export default function ProjectTable() {
   }, [dispatch, page, pageSize, searchText]);
 
   useEffect(() => {
-    console.log("📤 ProjectTable mount → loadProjects 호출");
     loadProjects();
   }, [loadProjects]);
 

--- a/src/features/project/pages/ProjectDetailPage.jsx
+++ b/src/features/project/pages/ProjectDetailPage.jsx
@@ -40,7 +40,6 @@ export default function ProjectDetailPage() {
     setConfirmOpen(false);
   };
 
-  // 아직 데이터가 로딩 중이라면 로딩 스피너
   if (!data) {
     return (
       <PageWrapper>
@@ -60,8 +59,19 @@ export default function ProjectDetailPage() {
 
   return (
     <PageWrapper>
-      <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-        <Box sx={{ flexShrink: 0 }}>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100vh",
+          width: "100%",
+          maxWidth: "100%",
+          boxSizing: "border-box",
+          overflowX: "hidden",
+        }}
+      >
+        {/* 1. PageHeader */}
+        <Box sx={{ flexShrink: 0, width: "100%" }}>
           <PageHeader
             title={data.name}
             subtitle={`프로젝트 ID: ${data.id}`}
@@ -97,8 +107,8 @@ export default function ProjectDetailPage() {
           onConfirm={handleDelete}
         />
 
-        {/* 요약 카드 영역 - 고정 높이 */}
-        <Box sx={{ flexShrink: 0 }}>
+        {/* 2. SummaryCard */}
+        <Box sx={{ flexShrink: 0, width: "100%" }}>
           <SummaryCard
             schema={[
               {
@@ -121,15 +131,19 @@ export default function ProjectDetailPage() {
           />
         </Box>
 
-        {/* 탭 컨텐츠 영역 - 남은 공간 모두 차지 */}
+        {/* 3. TabsWithContent 래핑 박스 */}
         <Box
           sx={{
+            /* flexGrow:1 으로 '헤더+카드' 제외한 남은 세로 공간 모두 차지 */
             flexGrow: 1,
-            pb: 3,
             display: "flex",
             flexDirection: "column",
-            height: "100%",
-            overflow: "hidden",
+            minHeight: 0,
+
+            /* mx:3 을 주고, 부모 폭 내에서만 크기 계산이 되도록 flex 설정 */
+            mx: 3,
+            flex: 1,            // → 부모(Box)에서 가능한 폭만큼 차지
+            minWidth: 0,        // → overflow 처리를 위해 반드시 필요
           }}
         >
           <TabsWithContent
@@ -140,56 +154,30 @@ export default function ProjectDetailPage() {
             ]}
             value={tab}
             onChange={(_, nv) => setTab(nv)}
+            containerSx={{
+              flexGrow: 1,
+              minHeight: 0,
+
+              /* 탭 콘텐츠가 가로로 넘칠 때 내부에서만 스크롤하도록 */
+              overflowX: "auto",
+
+              /* 부모 폭 내에서만 차지 (mx=3 만큼 양쪽 여유가 생겨도 그 안에서만 폭 계산) */
+              flex: 1,
+              minWidth: 0,
+            }}
             content={
               tab === 0 ? (
-                <Box
-                  sx={{
-                    height: "100%",
-                    display: "flex",
-                    flexDirection: "column",
-                    overflow: "hidden",
-                    bgcolor: "background.paper",
-                  }}
-                >
-                  <ProjectManagement
-                    initialStages={[
-                      "기획",
-                      "디자인",
-                      "퍼블리싱",
-                      "개발",
-                      "검수",
-                    ]}
-                    initialParticipants={[
-                      { id: 1, name: "이수하", avatarUrl: "/avatar1.jpg" },
-                      { id: 2, name: "김철수", avatarUrl: "/avatar2.jpg" },
-                    ]}
-                  />
-                </Box>
+                <ProjectManagement
+                  initialStages={["기획", "디자인", "퍼블리싱", "개발", "검수"]}
+                  initialParticipants={[
+                    { id: 1, name: "이수하", avatarUrl: "/avatar1.jpg" },
+                    { id: 2, name: "김철수", avatarUrl: "/avatar2.jpg" },
+                  ]}
+                />
               ) : tab === 1 ? (
-                <Box
-                  sx={{
-                    height: "100%",
-                    overflow: "hidden",
-                    bgcolor: "background.paper",
-                  }}
-                >
-                  <PostTable />
-                </Box>
+                <PostTable />
               ) : (
-                <Box
-                  sx={{
-                    height: "100%",
-                    overflow: "auto",
-                    p: 2,
-                    "&::-webkit-scrollbar": { width: 6 },
-                    "&::-webkit-scrollbar-thumb": {
-                      backgroundColor: (theme) => theme.palette.grey[300],
-                      borderRadius: 4,
-                    },
-                  }}
-                >
-                  <Typography>진척도 관리 콘텐츠</Typography>
-                </Box>
+                <Typography>진척도 관리 콘텐츠</Typography>
               )
             }
           />

--- a/src/utils/roleUtils.js
+++ b/src/utils/roleUtils.js
@@ -1,0 +1,14 @@
+export function getRoleLabel(role) {
+  switch (role) {
+    case "ROLE_SYSTEM_ADMIN":
+      return "시스템 관리자";
+    case "ROLE_DEV_ADMIN":
+      return "ROLE개발 관리자";
+    case "ROLE_CLIENT_ADMIN":
+      return "고객사 관리자";
+    case "ROLE_SER":
+      return "사용자";
+    default:
+      return "권한 없음";
+  }
+}


### PR DESCRIPTION
## 📌 개요

* `ProjectDetailPage` 컴포넌트의 전체 레이아웃을 고정하고, 내부 탭 콘텐츠 및 자식 컴포넌트의 스크롤 동작을 개선했습니다.
* 이로써 사이드 마진(`mx: 3`)을 적용해도 부모 폭이 깨지지 않고, 필요한 영역에서만 스크롤이 발생하도록 변경하였습니다.

---

## 🛠️ 변경 사항

* **최상위 컨테이너 레이아웃 고정**

  * `height: 100vh`, `display: flex`, `flexDirection: column` 설정하여 페이지 전체 레이아웃이 일정하게 유지되도록 함
  * `width: 100%`, `maxWidth: 100%`, `boxSizing: border-box` 추가해 부모 폭이 절대로 늘어나지 않도록 조정

* **탭 영역 래퍼(`Box`) 수정**

  * `mx: 3` 환경에서도 부모 폭을 유지하기 위해 `flex: 1`, `minWidth: 0` 속성을 적용
  * `overflowX: hidden` → `overflowX: auto` 또는 적절히 분리하여, 내부 콘텐츠 가로 넘침 시 스크롤만 동작

* **`TabsWithContent` 및 내부 콘텐츠 박스 수정**

  * `Paper`와 내부 `<Box>`에 `width: 100%`, `maxWidth: 100%`, `boxSizing: border-box` 적용
  * `overflowX: auto`, `overflowY: auto`를 사용해 가로·세로 스크롤 구간을 분리 (탭바 고정, 콘텐츠 영역만 스크롤)

* **내부 컴포넌트(`ProjectManagement`, `PostTable` 등) 업데이트**

  * 각 컴포넌트 최상위에 `width: 100%`, `maxWidth: 100%`, `boxSizing: border-box` 설정
  * `minWidth: 0` 과 `flex` 조합으로 부모 폭을 넘지 않도록 변경

---

## ✅ 주요 체크 포인트

* [ ] **최상위 레이아웃 고정 여부**

  * `height: 100vh`가 정상 작동하여, 페이지 전체 높이가 부모 컨테이너에 맞춰 고정되는지 확인
  * `width/maxWidth/boxSizing` 설정으로 부모 폭이 절대로 늘어나지 않는지 검증

* [ ] **탭 영역 래퍼 동작**

  * `mx: 3` 상태에서도 탭 콘텐츠가 부모 폭을 넘지 않고, 내부에서 가로 스크롤이 발생하는지 테스트
  * `flex: 1`, `minWidth: 0` 조합으로 여백을 제외한 실제 공간 내에서만 크기 계산되는지 확인

* [ ] **`TabsWithContent` 내 스크롤 분리**

  * 탭바(헤더) 고정, 콘텐츠 박스에서만 세로 스크롤이 발생하는지 확인
  * 가로 넘침 시 부모가 늘어나지 않고, 내부에서만 수평 스크롤이 동작하는지 검증

* [ ] **내부 컴포넌트 넘침 방지**

  * `ProjectManagement` 단계 카드/`PostTable` 테이블 등에서 가로 폭이 부모를 넘길 때, 내부 스크롤로 처리되는지 확인
  * `boxSizing: border-box`, `maxWidth: 100%` 적용으로 예기치 않은 레이아웃 깨짐이 없는지 점검

---

## 🔁 테스트 결과

* **기본 레이아웃 확인**

  1. 페이지 진입 시, 헤더(`PageHeader`)와 요약 카드(`SummaryCard`)가 고정된 높이로 정상 출력
  2. 탭 영역 아래 남은 세로 공간이 정확히 차지되고, 화면 리사이즈 시에도 전체 레이아웃이 일관되게 유지됨

* **`mx: 3` 적용 후 동작 테스트**

  1. 탭 영역 래퍼에 `mx: 3`을 주었을 때, 부모 폭(사이드바 너비 포함)이 늘어나지 않음
  2. 내부 컴포넌트(`ProjectManagement`, `PostTable`) 의 내용이 부모 폭을 넘어갈 때, 탭 콘텐츠 내부에서만 수평 스크롤 발생

* **탭 간 콘텐츠 스크롤 테스트**

  1. “프로젝트 관리” 탭: 단계 카드가 많아져도 여러 줄로 래핑되거나 내부에서 스크롤이 발생하여 부모 레이아웃 유지
  2. “업무 관리” 탭: 테이블 열이 많아져도 가로 스크롤이 내부에서만 발생, 부모 레이아웃 고정
  3. “진척도 관리” 탭: 단순 텍스트 콘텐츠가 길어질 때, 탭 콘텐츠 내부 세로 스크롤만 동작

* **페이지 새로고침/로그인 상태 유지 테스트**

  1. 로그인 상태에서 새로고침 시 `accessToken`으로 Redux 상태가 복원되고, 레이아웃이 깨지지 않음
  2. 로그아웃 이후 진입 시, 기대대로 `/login`으로 리다이렉트되고 레이아웃은 해당 페이지에 맞게 정상 동작

---

## 🔗 연관된 이슈

* `- #22` – ProjectDetailPage 레이아웃 및 스크롤 문제 보고
* `- #25` – 단계 카드/테이블 가로 넘침 이슈 개선 요청

---

## 📑 레퍼런스

* [[Material-UI Drawer / Layout 문서](https://mui.com/components/drawers/)](https://mui.com/components/drawers/)
* [[Flexbox 레이아웃 관련 가이드 – MDN](https://developer.mozilla.org/ko/docs/Web/CSS/CSS_Flexible_Box_Layout)](https://developer.mozilla.org/ko/docs/Web/CSS/CSS_Flexible_Box_Layout)
* [[React Router v6 레이아웃 예제](https://reactrouter.com/docs/en/v6/examples/layouts)](https://reactrouter.com/docs/en/v6/examples/layouts)