### PR TITLE
[feat] 개발사 생성 페이지 개발 (#61)

### DIFF
--- a/src/features/company/companySlice.js
+++ b/src/features/company/companySlice.js
@@ -23,9 +23,12 @@ export const createCompanyId = createAsyncThunk(
   "company/generateCompanyId",
   async (_, thunkAPI) => {
     try {
+      console.log("회사 ID 생성 API 호출 시작");
       const response = await companyAPI.generateCompanyId();
+      console.log("회사 ID 생성 API 응답:", response);
       return response.data;
     } catch (error) {
+      console.error("회사 ID 생성 API 에러:", error);
       return thunkAPI.rejectWithValue(error.response?.data || "Error");
     }
   }
@@ -44,10 +47,10 @@ export const fetchCompanyById = createAsyncThunk(
 );
 
 export const createCompany = createAsyncThunk(
-  "company/fetchCompanyById",
+  "company/createCompany",
   async (data, thunkAPI) => {
     try {
-      const response = await companyAPI.updateCompany(data);
+      const response = await companyAPI.createCompany(data);
       return response.data;
     } catch (error) {
       return thunkAPI.rejectWithValue(error.response?.data || "Error");
@@ -106,6 +109,21 @@ const companySlice = createSlice({
         state.totalCount = action.payload.data.totalCount;
       })
       .addCase(fetchCompanies.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      })
+      // ===== 회사 ID 생성 =====
+      .addCase(createCompanyId.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(createCompanyId.fulfilled, (state, action) => {
+        console.log("state: ", state);
+        console.log("action: ", action);
+        state.loading = false;
+        state.current = action.payload;
+      })
+      .addCase(createCompanyId.rejected, (state, action) => {
         state.loading = false;
         state.error = action.payload;
       });

--- a/src/features/company/components/DevCompanyForm.jsx
+++ b/src/features/company/components/DevCompanyForm.jsx
@@ -1,0 +1,169 @@
+import React from "react";
+import {
+  TextField,
+  Paper,
+  Stack,
+  Box,
+  Typography,
+  Divider,
+  Grid,
+  Tooltip,
+} from "@mui/material";
+import { InfoOutlined } from "@mui/icons-material";
+
+export default function DevCompanyForm({
+  form,
+  handleChange,
+  isSubmitted = false,
+}) {
+  return (
+    <Box sx={{ display: "flex", flexDirection: "column", flex: 1 }}>
+      <Paper
+        sx={{
+          p: 4,
+          mb: 3,
+          mx: 3,
+          borderRadius: 2,
+          boxShadow: 2,
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          boxSizing: "border-box",
+        }}
+      >
+        <Stack spacing={4} sx={{ flex: 1 }}>
+          {/* 1) 기본 정보 섹션 */}
+          <Box>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                1. 기본 정보
+              </Typography>
+              <Tooltip title="회사 이름은 필수 입력 항목입니다.">
+                <InfoOutlined fontSize="small" color="action" />
+              </Tooltip>
+            </Stack>
+            <Divider sx={{ mt: 1, mb: 2 }} />
+
+            <Grid container spacing={3}>
+              <Grid item xs={12}>
+                <TextField
+                  required
+                  label="회사 이름"
+                  placeholder="예) MyWork"
+                  helperText={
+                    isSubmitted && !form.name ? "회사 이름을 입력해주세요." : ""
+                  }
+                  error={isSubmitted && !form.name}
+                  value={form.name || ""}
+                  onChange={handleChange("name")}
+                  fullWidth
+                />
+                <TextField
+                  label="상세 설명"
+                  placeholder="회사에 대한 상세 설명을 입력해주세요."
+                  multiline
+                  rows={4}
+                  value={form.detail || ""}
+                  onChange={handleChange("detail")}
+                  fullWidth
+                  sx={{ mt: 2 }}
+                />
+              </Grid>
+            </Grid>
+          </Box>
+
+          {/* 2) 사업자 정보 섹션 */}
+          <Box>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                2. 사업자 정보
+              </Typography>
+              <Tooltip title="사업자 정보를 입력하세요.">
+                <InfoOutlined fontSize="small" color="action" />
+              </Tooltip>
+            </Stack>
+            <Divider sx={{ mt: 1, mb: 2 }} />
+
+            <Grid container spacing={3}>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="사업자 번호"
+                  placeholder="000-00-00000"
+                  value={form.businessNumber || ""}
+                  onChange={handleChange("businessNumber")}
+                  fullWidth
+                />
+              </Grid>
+            </Grid>
+          </Box>
+
+          {/* 3) 연락처 정보 섹션 */}
+          <Box>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                3. 연락처 정보
+              </Typography>
+              <Tooltip title="연락처 정보를 입력하세요.">
+                <InfoOutlined fontSize="small" color="action" />
+              </Tooltip>
+            </Stack>
+            <Divider sx={{ mt: 1, mb: 2 }} />
+
+            <Grid container spacing={3}>
+              <Grid item xs={12}>
+                <TextField
+                  label="주소"
+                  placeholder="회사 주소를 입력해주세요."
+                  value={form.address || ""}
+                  onChange={handleChange("address")}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="회사 전화번호"
+                  placeholder="02-0000-0000"
+                  value={form.contactPhoneNumber || ""}
+                  onChange={handleChange("contactPhoneNumber")}
+                  fullWidth
+                />
+              </Grid>
+              <Grid item xs={12} sm={6}>
+                <TextField
+                  label="이메일"
+                  type="email"
+                  placeholder="company@example.com"
+                  value={form.contactEmail || ""}
+                  onChange={handleChange("contactEmail")}
+                  fullWidth
+                />
+              </Grid>
+            </Grid>
+          </Box>
+
+          {/* 4) 로고 이미지 섹션 */}
+          <Box>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                4. 로고 이미지
+              </Typography>
+              <Tooltip title="회사 로고 이미지 경로를 입력하세요.">
+                <InfoOutlined fontSize="small" color="action" />
+              </Tooltip>
+            </Stack>
+            <Divider sx={{ mt: 1, mb: 2 }} />
+
+            <TextField
+              label="로고 이미지 경로"
+              placeholder="/images/company-logo.png"
+              value={form.logoImagePath || ""}
+              onChange={handleChange("logoImagePath")}
+              fullWidth
+            />
+          </Box>
+        </Stack>
+      </Paper>
+    </Box>
+  );
+}

--- a/src/features/company/pages/DevCompanyFormPage.jsx
+++ b/src/features/company/pages/DevCompanyFormPage.jsx
@@ -1,0 +1,157 @@
+// src/features/project/pages/ProjectFormPage.jsx
+
+import React, { useState, useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  fetchCompanyById,
+  createCompany,
+  updateCompany,
+  createCompanyId,
+} from "@/features/company/companySlice";
+import { Box, Button, Stack } from "@mui/material";
+import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
+import PageHeader from "@/components/layouts/pageHeader/PageHeader";
+import DevCompanyForm from "../components/DevCompanyForm";
+
+export default function DevCompanyFormPage() {
+  const { id } = useParams();
+  const isEdit = Boolean(id);
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+
+  // Redux 상태 조회
+  const { current, loading: companyLoading } = useSelector(
+    (state) => state.company
+  );
+
+  // 로컬 폼 상태
+  const [form, setForm] = useState({
+    id: "",
+    name: "",
+    detail: "",
+    businessNumber: "",
+    address: "",
+    type: "DEV",
+    contactPhoneNumber: "",
+    contactEmail: "",
+    logoImagePath: "",
+  });
+
+  const [isSubmitted, setIsSubmitted] = useState(false);
+
+  // 새로운 회사 ID 생성 및 localStorage 저장
+  useEffect(() => {
+    const generateNewCompanyId = async () => {
+      if (!isEdit) {
+        console.log("회사 ID 생성 시작 - isEdit:", isEdit);
+        const storedId = localStorage.getItem("newCompanyId");
+        console.log("저장된 ID:", storedId);
+        if (!storedId) {
+          try {
+            console.log("새로운 회사 ID 생성 요청");
+            const result = await dispatch(createCompanyId()).unwrap();
+            console.log("회사 ID 생성 결과:", result);
+            localStorage.setItem("newCompanyId", result.data.companyId);
+            console.log("local storage:", localStorage.getItem("newCompanyId"));
+            setForm((prev) => ({ ...prev, id: result.data.companyId }));
+          } catch (err) {
+            console.error("회사 ID 생성 실패:", err);
+          }
+        } else {
+          setForm((prev) => ({ ...prev, id: storedId }));
+        }
+      }
+    };
+
+    generateNewCompanyId();
+  }, [dispatch, isEdit]);
+
+  // 편집 모드일 때 기존 회사 데이터 로드
+  useEffect(() => {
+    if (isEdit) {
+      dispatch(fetchCompanyById(id));
+    }
+  }, [dispatch, id, isEdit]);
+
+  // current 데이터가 바뀌면 form 상태에 반영
+  useEffect(() => {
+    if (isEdit && current) {
+      setForm({
+        id: current.id || null,
+        name: current.name || "",
+        detail: current.detail || "",
+        businessNumber: current.businessNumber || "",
+        address: current.address || "",
+        type: current.type || "DEV",
+        contactPhoneNumber: current.contactPhoneNumber || "",
+        contactEmail: current.contactEmail || "",
+        logoImagePath: current.logoImagePath || "",
+      });
+    }
+  }, [isEdit, current]);
+
+  // 각 필드 변경 핸들러
+  const handleChange = (key) => (e) => {
+    setForm((prev) => ({ ...prev, [key]: e.target.value }));
+  };
+
+  // 제출 처리
+  const handleSubmit = async () => {
+    setIsSubmitted(true);
+    if (!form.name) return;
+
+    try {
+      if (isEdit) {
+        await dispatch(updateCompany({ id, ...form })).unwrap();
+        navigate(`/dev-companies/${id}`);
+      } else {
+        await dispatch(createCompany(form)).unwrap();
+        localStorage.removeItem("newCompanyId"); // 성공적으로 생성 후 localStorage에서 제거
+        navigate("/dev-companies");
+      }
+    } catch (err) {
+      console.error(err);
+      // TODO: 에러 발생 시 스낵바/토스트 표시
+    }
+  };
+
+  // 취소 시 뒤로 이동
+  const handleCancel = () => {
+    navigate(-1);
+  };
+
+  // 헤더 우측에 들어갈 버튼들
+  const headerAction = (
+    <Stack direction="row" spacing={2}>
+      <Button variant="outlined" onClick={handleCancel}>
+        취소
+      </Button>
+      <Button
+        variant="contained"
+        color="primary"
+        onClick={handleSubmit}
+        disabled={companyLoading || !form.name}
+      >
+        {companyLoading ? "로딩 중..." : isEdit ? "수정 저장" : "생성"}
+      </Button>
+    </Stack>
+  );
+
+  return (
+    <PageWrapper>
+      <PageHeader
+        title={isEdit ? "개발사 수정" : "개발사 생성"}
+        subtitle="새로운 개발사를 등록해주세요."
+        action={headerAction}
+      />
+
+      <DevCompanyForm
+        form={form}
+        handleChange={handleChange}
+        isEdit={isEdit}
+        isSubmitted={isSubmitted}
+      />
+    </PageWrapper>
+  );
+}

--- a/src/features/company/pages/DevCompanyPage.jsx
+++ b/src/features/company/pages/DevCompanyPage.jsx
@@ -29,7 +29,7 @@ export default function ProjectPage() {
           action={
             <CustomButton
               startIcon={<Add />}
-              onClick={() => navigate("/projects/new")}
+              onClick={() => navigate("/dev-companies/new")}
             >
               회사 생성
             </CustomButton>

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -4,6 +4,7 @@ import ProjectPage from "@/features/project/pages/ProjectPage";
 import ProjectDetailPage from "@/features/project/pages/ProjectDetailPage";
 import ProjectFormPage from "@/features/project/pages/ProjectFormPage";
 import DevCompanyPage from "@/features/company/pages/DevCompanyPage";
+import DevCompanyFormPage from "@/features/company/pages/DevCompanyFormPage";
 import MainLayout from "@/layouts/MainLayout";
 import LoginPage from "@/features/auth/pages/LoginPage";
 import { useSelector } from "react-redux";
@@ -35,6 +36,7 @@ export default function MainRoutes() {
         <Route path="/projects/:id/edit" element={<ProjectFormPage />} />
         <Route path="/members" element={<MemberPage />} />
         <Route path="/dev-companies" element={<DevCompanyPage />} />
+        <Route path="/dev-companies/new" element={<DevCompanyFormPage />} />
       </Route>
     </Routes>
   );


### PR DESCRIPTION
- 생성 페이지 이동 시 개발사 생성 API 요청
- 중복 요청 방지를 위한 개발사 아이디 로컬 스토리지에 저장
- 이미지는 presigned url 개발 이전이므로 임의로 입력해서 저장하는 방식으로 적용

## 📌 개요

- 개발사 생성 페이지 개발

## 🛠️ 변경 사항

- 개발사 생성 페이지 이동 시에 개발사 아이디 생성 API 호출 및 로컬 스토리지 저장
- presigned url 개발 이전으로 임시 임시 path 설정으로 값 저장 설정

## ✅ 주요 체크 포인트

## 🔁 테스트 결과

## 🔗 연관된 이슈

- #61 
