### PR TITLE
[refactor]사이드바 메뉴 렌더링 구조 리팩토링(#190)

### DIFF
--- a/constants/navItems.js
+++ b/constants/navItems.js
@@ -1,33 +1,16 @@
 // src/components/layout/navItems.js
-import DeveloperModeRoundedIcon from "@mui/icons-material/DeveloperModeRounded";
+import DashboardIcon from "@mui/icons-material/Dashboard";
+import FolderRoundedIcon from "@mui/icons-material/FolderRounded";
 import BusinessRoundedIcon from "@mui/icons-material/BusinessRounded";
 import PersonIcon from "@mui/icons-material/Person";
-import FolderRoundedIcon from "@mui/icons-material/FolderRounded";
-import HistoryRoundedIcon from "@mui/icons-material/HistoryRounded";
+import AddBoxRoundedIcon from "@mui/icons-material/AddBoxRounded";
+import ListRoundedIcon from "@mui/icons-material/ListRounded";
 
 const navItems = [
   {
-    text: "개발사 관리",
-    icon: DeveloperModeRoundedIcon,
-    path: "/dev-companies",
-    roles: ["ROLE_SYSTEM_ADMIN"],
-  },
-  {
-    text: "고객사 관리",
-    icon: BusinessRoundedIcon,
-    path: "/client-companies",
-    roles: ["ROLE_SYSTEM_ADMIN"],
-  },
-  {
-    text: "회원 관리",
-    icon: PersonIcon,
-    path: "/members",
-    roles: ["ROLE_SYSTEM_ADMIN", "ROLE_DEV_ADMIN", "ROLE_CLIENT_ADMIN"],
-  },
-  {
-    text: "프로젝트 관리",
-    icon: FolderRoundedIcon,
-    path: "/projects",
+    text: "대시보드",
+    icon: DashboardIcon,
+    path: "/dashboard",
     roles: [
       "ROLE_SYSTEM_ADMIN",
       "ROLE_DEV_ADMIN",
@@ -36,10 +19,60 @@ const navItems = [
     ],
   },
   {
-    text: "로그",
-    icon: HistoryRoundedIcon,
-    path: "/logs",
+    text: "프로젝트",
+    icon: FolderRoundedIcon,
+    roles: [
+      "ROLE_SYSTEM_ADMIN",
+      "ROLE_DEV_ADMIN",
+      "ROLE_CLIENT_ADMIN",
+      "ROLE_USER",
+    ],
+    children: [
+      {
+        text: "프로젝트 생성",
+        icon: AddBoxRoundedIcon,
+        path: "/projects/create",
+      },
+      {
+        text: "프로젝트 목록",
+        icon: ListRoundedIcon,
+        path: "/projects",
+      },
+    ],
+  },
+  {
+    text: "업체",
+    icon: BusinessRoundedIcon,
     roles: ["ROLE_SYSTEM_ADMIN"],
+    children: [
+      {
+        text: "업체 생성",
+        icon: AddBoxRoundedIcon,
+        path: "/companies/create",
+      },
+      {
+        text: "업체 목록",
+        icon: ListRoundedIcon,
+        path: "/companies",
+      },
+    ],
+  },
+  {
+    text: "회원",
+    icon: PersonIcon,
+    roles: ["ROLE_SYSTEM_ADMIN", "ROLE_DEV_ADMIN", "ROLE_CLIENT_ADMIN"],
+    children: [
+      {
+        text: "회원 생성",
+        icon: AddBoxRoundedIcon,
+        path: "/members/create",
+      },
+      {
+        text: "회원 목록",
+        icon: ListRoundedIcon,
+        path: "/members",
+      },
+    ],
   },
 ];
 

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import {
@@ -23,7 +23,6 @@ import {
   logout as logoutThunk,
   clearAuthState,
 } from "@/features/auth/authSlice";
-import { fetchMemberProjects } from "@/features/member/memberSlice";
 
 export default function Sidebar({ onClose }) {
   const navigate = useNavigate();
@@ -32,19 +31,11 @@ export default function Sidebar({ onClose }) {
 
   const memberName = useSelector((state) => state.auth.user?.name);
   const memberRole = useSelector((state) => state.auth.user?.role);
-  const memberId = useSelector((state) => state.auth.user?.id);
-  const memberProjects = useSelector((state) => state.member.memberProjects);
   const currentPath = location.pathname;
 
   const filteredNavItems = navItems.filter(
     (item) => item.roles && item.roles.includes(memberRole)
   );
-
-  useEffect(() => {
-    if (memberRole === "ROLE_USER" && memberId) {
-      dispatch(fetchMemberProjects(memberId));
-    }
-  }, [memberRole, memberId, dispatch]);
 
   const handleItemClick = (path) => {
     onClose();
@@ -75,63 +66,59 @@ export default function Sidebar({ onClose }) {
       </ProfileSection>
 
       <NavList>
-        {memberRole === "ROLE_USER" ? (
-          <Box sx={{ p: 2 }}>
-            <Typography variant="caption" color="text.secondary" sx={{ mb: 1 }}>
-              프로젝트
-            </Typography>
-            {memberProjects.map((project) => (
-              <NavItem
-                key={project.projectId}
-                onClick={() =>
-                  handleItemClick(`/projects/${project.projectId}`)
-                }
-                disablePadding
-                sx={{ mb: 0.5 }}
-              >
-                <ListItemButton
-                  selected={currentPath === `/projects/${project.projectId}`}
-                  sx={{ borderRadius: 1, px: 1.5, py: 0.8 }}
-                >
-                  <ListItemText
-                    primary={project.projectName}
-                    primaryTypographyProps={{
-                      noWrap: true,
-                      sx: { fontSize: 14 },
-                    }}
-                  />
-                </ListItemButton>
-              </NavItem>
-            ))}
-          </Box>
-        ) : (
-          <Box sx={{ p: 2 }}>
-            {filteredNavItems.map(({ text, icon: Icon, path, children }) => (
-              <Box key={text} sx={{ mb: 2 }}>
+        <Box>
+          {filteredNavItems.map(({ text, icon: Icon, path, children }) => (
+            <Box key={text} sx={{ mb: 2 }}>
+              {/* children 있을 때만 섹션 타이틀 노출 */}
+              {children && (
                 <Typography
                   variant="caption"
-                  color="text.secondary"
-                  sx={{ mb: 1, pl: 1 }}
+                  color="primary.contrastText"
+                  sx={{ pl: 1 }}
                 >
                   {text}
                 </Typography>
+              )}
 
-                {/* 상위가 children이 없는 경우는 단일 메뉴 처리 */}
-                {!children && (
+              {/* children 없는 경우 단일 메뉴 */}
+              {!children && (
+                <NavItem disablePadding onClick={() => handleItemClick(path)}>
+                  <ListItemButton
+                    selected={currentPath === path}
+                    sx={{ borderRadius: 1, px: 1, py: 0.8 }}
+                  >
+                    <ListItemIcon sx={{ minWidth: 32 }}>
+                      <Icon fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={text}
+                      primaryTypographyProps={{
+                        noWrap: true,
+                        sx: { fontSize: 14 },
+                      }}
+                    />
+                  </ListItemButton>
+                </NavItem>
+              )}
+
+              {/* children 있는 경우 하위 메뉴 노출 */}
+              {children?.map(
+                ({ text: childText, icon: ChildIcon, path: childPath }) => (
                   <NavItem
+                    key={childText}
                     disablePadding
-                    onClick={() => handleItemClick(path)}
-                    sx={{ mb: 0.5 }}
+                    onClick={() => handleItemClick(childPath)}
+                    sx={{ pl: 3 }}
                   >
                     <ListItemButton
-                      selected={currentPath === path}
+                      selected={currentPath === childPath}
                       sx={{ borderRadius: 1, px: 1.5, py: 0.8 }}
                     >
                       <ListItemIcon sx={{ minWidth: 32 }}>
-                        <Icon fontSize="small" />
+                        <ChildIcon fontSize="small" />
                       </ListItemIcon>
                       <ListItemText
-                        primary={text}
+                        primary={childText}
                         primaryTypographyProps={{
                           noWrap: true,
                           sx: { fontSize: 14 },
@@ -139,39 +126,11 @@ export default function Sidebar({ onClose }) {
                       />
                     </ListItemButton>
                   </NavItem>
-                )}
-
-                {/* children 있는 경우 하위 메뉴 리스트 노출 */}
-                {children?.map(
-                  ({ text: childText, icon: ChildIcon, path: childPath }) => (
-                    <NavItem
-                      key={childText}
-                      disablePadding
-                      onClick={() => handleItemClick(childPath)}
-                      sx={{ pl: 3, mb: 0.5 }}
-                    >
-                      <ListItemButton
-                        selected={currentPath === childPath}
-                        sx={{ borderRadius: 1, px: 1.5, py: 0.8 }}
-                      >
-                        <ListItemIcon sx={{ minWidth: 32 }}>
-                          <ChildIcon fontSize="small" />
-                        </ListItemIcon>
-                        <ListItemText
-                          primary={childText}
-                          primaryTypographyProps={{
-                            noWrap: true,
-                            sx: { fontSize: 14 },
-                          }}
-                        />
-                      </ListItemButton>
-                    </NavItem>
-                  )
-                )}
-              </Box>
-            ))}
-          </Box>
-        )}
+                )
+              )}
+            </Box>
+          ))}
+        </Box>
       </NavList>
 
       <Box sx={{ mt: "auto" }}>

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -1,4 +1,3 @@
-// src/components/layout/Sidebar.jsx
 import React, { useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
@@ -34,17 +33,13 @@ export default function Sidebar({ onClose }) {
   const memberName = useSelector((state) => state.auth.user?.name);
   const memberRole = useSelector((state) => state.auth.user?.role);
   const memberId = useSelector((state) => state.auth.user?.id);
-
   const memberProjects = useSelector((state) => state.member.memberProjects);
-  const projects = useSelector((state) => state.project.data); // 관리자용
-
   const currentPath = location.pathname;
 
   const filteredNavItems = navItems.filter(
     (item) => item.roles && item.roles.includes(memberRole)
   );
 
-  // 새로고침 시 memberProjects 재조회
   useEffect(() => {
     if (memberRole === "ROLE_USER" && memberId) {
       dispatch(fetchMemberProjects(memberId));
@@ -80,36 +75,103 @@ export default function Sidebar({ onClose }) {
       </ProfileSection>
 
       <NavList>
-        {memberRole === "ROLE_USER"
-          ? memberProjects.map((project) => (
+        {memberRole === "ROLE_USER" ? (
+          <Box sx={{ p: 2 }}>
+            <Typography variant="caption" color="text.secondary" sx={{ mb: 1 }}>
+              프로젝트
+            </Typography>
+            {memberProjects.map((project) => (
               <NavItem
                 key={project.projectId}
                 onClick={() =>
                   handleItemClick(`/projects/${project.projectId}`)
                 }
                 disablePadding
+                sx={{ mb: 0.5 }}
               >
                 <ListItemButton
                   selected={currentPath === `/projects/${project.projectId}`}
+                  sx={{ borderRadius: 1, px: 1.5, py: 0.8 }}
                 >
-                  <ListItemText primary={project.projectName} />
-                </ListItemButton>
-              </NavItem>
-            ))
-          : filteredNavItems.map(({ text, icon: Icon, path }) => (
-              <NavItem
-                key={text}
-                onClick={() => handleItemClick(path)}
-                disablePadding
-              >
-                <ListItemButton selected={currentPath === path}>
-                  <ListItemIcon>
-                    <Icon />
-                  </ListItemIcon>
-                  <ListItemText primary={text} />
+                  <ListItemText
+                    primary={project.projectName}
+                    primaryTypographyProps={{
+                      noWrap: true,
+                      sx: { fontSize: 14 },
+                    }}
+                  />
                 </ListItemButton>
               </NavItem>
             ))}
+          </Box>
+        ) : (
+          <Box sx={{ p: 2 }}>
+            {filteredNavItems.map(({ text, icon: Icon, path, children }) => (
+              <Box key={text} sx={{ mb: 2 }}>
+                <Typography
+                  variant="caption"
+                  color="text.secondary"
+                  sx={{ mb: 1, pl: 1 }}
+                >
+                  {text}
+                </Typography>
+
+                {/* 상위가 children이 없는 경우는 단일 메뉴 처리 */}
+                {!children && (
+                  <NavItem
+                    disablePadding
+                    onClick={() => handleItemClick(path)}
+                    sx={{ mb: 0.5 }}
+                  >
+                    <ListItemButton
+                      selected={currentPath === path}
+                      sx={{ borderRadius: 1, px: 1.5, py: 0.8 }}
+                    >
+                      <ListItemIcon sx={{ minWidth: 32 }}>
+                        <Icon fontSize="small" />
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={text}
+                        primaryTypographyProps={{
+                          noWrap: true,
+                          sx: { fontSize: 14 },
+                        }}
+                      />
+                    </ListItemButton>
+                  </NavItem>
+                )}
+
+                {/* children 있는 경우 하위 메뉴 리스트 노출 */}
+                {children?.map(
+                  ({ text: childText, icon: ChildIcon, path: childPath }) => (
+                    <NavItem
+                      key={childText}
+                      disablePadding
+                      onClick={() => handleItemClick(childPath)}
+                      sx={{ pl: 3, mb: 0.5 }}
+                    >
+                      <ListItemButton
+                        selected={currentPath === childPath}
+                        sx={{ borderRadius: 1, px: 1.5, py: 0.8 }}
+                      >
+                        <ListItemIcon sx={{ minWidth: 32 }}>
+                          <ChildIcon fontSize="small" />
+                        </ListItemIcon>
+                        <ListItemText
+                          primary={childText}
+                          primaryTypographyProps={{
+                            noWrap: true,
+                            sx: { fontSize: 14 },
+                          }}
+                        />
+                      </ListItemButton>
+                    </NavItem>
+                  )
+                )}
+              </Box>
+            ))}
+          </Box>
+        )}
       </NavList>
 
       <Box sx={{ mt: "auto" }}>


### PR DESCRIPTION
## 📌 개요

* 사이드바 메뉴 렌더링 구조를 리팩토링하여 확장성과 일관성을 개선했습니다.

## 🛠️ 변경 사항

* children 유무에 따라 섹션 타이틀(`Typography`) 노출 방식 분리
* 토글(Collapse) 제거 후 항상 펼쳐진 형태로 하위 메뉴 노출
* ROLE\_USER 분기 제거 → 전체 공통 렌더링 구조 통합
* navItems 구조 기반으로 유연하게 children 기반 렌더링
* 전체 코드 가독성 및 유지보수성 개선

## ✅ 주요 체크 포인트

* [ ] 메뉴 권한별 정상 렌더링 여부 (navItems → roles 확인)
* [ ] children이 없는 경우 섹션 타이틀 노출 여부 확인
* [ ] active 메뉴 highlighting 정상 작동 여부

## 🔁 테스트 결과

* 로컬에서 권한별 계정으로 로그인하여 전체 사이드바 메뉴 렌더링 확인
* navItems 구조에 맞게 정상 렌더링 및 클릭 시 페이지 이동 확인
* children 유무에 따른 UI 정상 동작 확인

## 🔗 연관된 이슈

* #190 

## 📑 레퍼런스

* 없음
