### PR TITLE
[refactor]ProjectDetailPage 탭 제거 및 ContentContainer 공통 컴포넌트 적용(#201)

### DIFF
--- a/src/components/layouts/contentContainer/ContentContainer.jsx
+++ b/src/components/layouts/contentContainer/ContentContainer.jsx
@@ -1,0 +1,26 @@
+// src/components/layouts/ContentContainer.jsx
+import React from "react";
+import { Paper } from "@mui/material";
+
+export default function ContentContainer({ children, sx }) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        minHeight: 0,
+        borderRadius: 3,
+        border: "1px solid",
+        borderColor: "divider",
+        overflow: "hidden",
+        px: 3,
+        mb: 3,
+        ...sx,
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}

--- a/src/features/project/pages/ProjectDetailPage.jsx
+++ b/src/features/project/pages/ProjectDetailPage.jsx
@@ -1,7 +1,6 @@
-// src/pages/project/ProjectDetailPage.jsx
 import React, { useState, useEffect } from "react";
-import { Stack, Box, CircularProgress, Typography } from "@mui/material";
-import { useParams, useNavigate, useLocation } from "react-router-dom"; 
+import { Stack, Box, CircularProgress } from "@mui/material";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
 import PageHeader from "@/components/layouts/pageHeader/PageHeader";
 import { useDispatch, useSelector } from "react-redux";
@@ -12,45 +11,42 @@ import {
 import ConfirmDialog from "@/components/common/confirmDialog/ConfirmDialog";
 import CustomButton from "@/components/common/customButton/CustomButton";
 import SummaryCard from "@/components/common/summaryCard/SummaryCard";
-import TabsWithContent from "@/components/layouts/tabsWithContent/TabsWithContent";
 import PostTable from "../post/components/PostTable";
 import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
 import CreateRoundedIcon from "@mui/icons-material/CreateRounded";
-import VisibilityIcon from "@mui/icons-material/Visibility";
-import TaskIcon from "@mui/icons-material/AssignmentTurnedIn";
-import DownloadIcon from "@mui/icons-material/Download";
 import ProjectManagement from "../management/pages/ProjectManagement";
 import dayjs from "dayjs";
-import ProgressOverview from "../checklist/pages/ProgressOverview"
+import ProgressOverview from "../checklist/pages/ProgressOverview";
+import ToggleButton from "@mui/material/ToggleButton";
+import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
+import ContentContainer from "@/components/layouts/contentContainer/ContentContainer";
 
 export default function ProjectDetailPage() {
-   const { id } = useParams();
+  const { id } = useParams();
   const navigate = useNavigate();
-  const location = useLocation();                                   // ← 추가
+  const location = useLocation();
   const dispatch = useDispatch();
   const projectState = useSelector((state) => state.project) || {};
   const { current: project } = projectState;
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const statusMap = {
-  NOT_STARTED: { color: 'neutral', label: '계획' },
-  IN_PROGRESS: { color: 'info',    label: '진행' },
-  PAUSED:      { color: 'warning', label: '중단' },
-  COMPLETED:   { color: 'success', label: '완료' },
-}
+    NOT_STARTED: { color: "neutral", label: "계획" },
+    IN_PROGRESS: { color: "info", label: "진행" },
+    PAUSED: { color: "warning", label: "중단" },
+    COMPLETED: { color: "success", label: "완료" },
+  };
 
-  // URL 에서 탭 결정: /projects/:id/management  → 0, /tasks → 1, /progress → 2
   const tabMap = {
     management: 0,
-    tasks:      1,
-    progress:   2,
+    tasks: 1,
+    progress: 2,
   };
-  // pathname segments 중 마지막 부분으로 탭 인덱스 가져오기
+
   const segments = location.pathname.split("/");
   const currentTab = tabMap[segments[segments.length - 1]] ?? 0;
-
   const [tab, setTab] = useState(currentTab);
-  // 탭 변경 시 URL 이동
+
   const handleTabChange = (_, newIndex) => {
     setTab(newIndex);
     const routeKeys = ["management", "tasks", "progress"];
@@ -62,14 +58,10 @@ export default function ProjectDetailPage() {
   }, [dispatch, id]);
 
   const handleDelete = () => {
-    // deleteProject에 { id } 형태로 넘깁니다
     dispatch(deleteProject({ id }))
       .unwrap()
       .then(() => {
         navigate("/projects");
-      })
-      .catch(() => {
-        // 에러 처리 로직 (예: 알림)
       });
     setConfirmOpen(false);
   };
@@ -97,32 +89,31 @@ export default function ProjectDetailPage() {
           overflowX: "hidden",
         }}
       >
-        {/* 1. PageHeader */}
+        {/* Header */}
         <Box sx={{ flexShrink: 0, width: "100%" }}>
           <PageHeader
             title={project.name}
             subtitle={project.detail}
             action={
-              <Stack direction="row" spacing={1}>
-                <CustomButton
-                  kind="danger"
-                  startIcon={<DeleteRoundedIcon />}
-                  onClick={() => setConfirmOpen(true)}
+              <Stack direction="row" spacing={2}>
+                <ToggleButtonGroup
+                  value={tab}
+                  exclusive
+                  onChange={handleTabChange}
+                  size="small"
+                  color="primary"
                 >
-                  삭제하기
-                </CustomButton>
-                <CustomButton
-                  startIcon={<CreateRoundedIcon />}
-                  onClick={() => navigate(`/projects/${id}/edit`)}
-                >
-                  수정하기
-                </CustomButton>
+                  <ToggleButton value={0}>프로젝트 관리</ToggleButton>
+                  <ToggleButton value={1}>업무 관리</ToggleButton>
+                  <ToggleButton value={2}>결재 관리</ToggleButton>
+                </ToggleButtonGroup>
               </Stack>
             }
             noPaddingBottom
           />
         </Box>
 
+        {/* 삭제 다이얼로그 */}
         <ConfirmDialog
           open={confirmOpen}
           title="프로젝트를 삭제하시겠습니까?"
@@ -134,90 +125,73 @@ export default function ProjectDetailPage() {
           onConfirm={handleDelete}
         />
 
-        {/* 2. SummaryCard */}
+        {/* Summary */}
         <Box sx={{ flexShrink: 0, width: "100%" }}>
           <SummaryCard
-  schema={[
-    {
-      key: 'step',
-      label: '상태',
-      type: 'status',
-      colorMap: {
-        NOT_STARTED: statusMap.NOT_STARTED.color,
-        IN_PROGRESS: statusMap.IN_PROGRESS.color,
-        PAUSED:      statusMap.PAUSED.color,
-        COMPLETED:   statusMap.COMPLETED.color,
-      },
-      labelMap: {
-        NOT_STARTED: statusMap.NOT_STARTED.label,
-        IN_PROGRESS: statusMap.IN_PROGRESS.label,
-        PAUSED:      statusMap.PAUSED.label,
-        COMPLETED:   statusMap.COMPLETED.label,
-      },
-    },
-    {
-      key: 'period',
-      label: '기간',
-      type: 'text',
-    },
-    {
-      key: 'clientCompanyName',
-      label: '고객사',
-      type: 'text',
-    },
-    {
-      key: 'clientContactPhoneNum',
-      label: '고객사 연락처',
-      type: 'text',
-    },
-    {
-      key: 'devCompanyName',
-      label: '개발사',
-      type: 'text',
-    },
-    {
-      key: 'devContactPhoneNum',
-      label: '개발사 연락처',
-      type: 'text',
-    },
-  ]}
-  data={{
-    step: project.step,
-    period: `${dayjs(project.startAt).format('YYYY.MM.DD')} ~ ${dayjs(project.endAt).format('YYYY.MM.DD')}`,
-    clientCompanyName: project.clientCompanyName,
-    clientContactPhoneNum: project.clientContactPhoneNum,
-    devCompanyName: project.devCompanyName,
-    devContactPhoneNum: project.devContactPhoneNum,
-  }}
-  noMarginBottom
-/>
+            schema={[
+              {
+                key: "step",
+                label: "상태",
+                type: "status",
+                colorMap: {
+                  NOT_STARTED: statusMap.NOT_STARTED.color,
+                  IN_PROGRESS: statusMap.IN_PROGRESS.color,
+                  PAUSED: statusMap.PAUSED.color,
+                  COMPLETED: statusMap.COMPLETED.color,
+                },
+                labelMap: {
+                  NOT_STARTED: statusMap.NOT_STARTED.label,
+                  IN_PROGRESS: statusMap.IN_PROGRESS.label,
+                  PAUSED: statusMap.PAUSED.label,
+                  COMPLETED: statusMap.COMPLETED.label,
+                },
+              },
+              { key: "period", label: "기간", type: "text" },
+              { key: "clientCompanyName", label: "고객사", type: "text" },
+              {
+                key: "clientContactPhoneNum",
+                label: "고객사 연락처",
+                type: "text",
+              },
+              { key: "devCompanyName", label: "개발사", type: "text" },
+              {
+                key: "devContactPhoneNum",
+                label: "개발사 연락처",
+                type: "text",
+              },
+            ]}
+            data={{
+              step: project.step,
+              period: `${dayjs(project.startAt).format("YYYY.MM.DD")} ~ ${dayjs(project.endAt).format("YYYY.MM.DD")}`,
+              clientCompanyName: project.clientCompanyName,
+              clientContactPhoneNum: project.clientContactPhoneNum,
+              devCompanyName: project.devCompanyName,
+              devContactPhoneNum: project.devContactPhoneNum,
+            }}
+            noMarginBottom
+          />
         </Box>
 
-        {/* 3. TabsWithContent 래핑 박스 */}
-        <Box sx={{ flexGrow:1, display:"flex", flexDirection:"column", mx:3, flex:1, minWidth:0 }}>
-        <TabsWithContent
-          tabs={[
-            { label: "프로젝트 관리", icon: <VisibilityIcon /> },
-            { label: "업무 관리",     icon: <TaskIcon /> },
-            { label: "진척도 관리",   icon: <DownloadIcon /> },
-          ]}
-          value={tab}
-          onChange={handleTabChange} 
-          containerSx={{
-            flexGrow:1, minHeight:0,
-            overflowX:"auto", flex:1, minWidth:0
+        {/* Content */}
+        <Box
+          sx={{
+            flexGrow: 1,
+            display: "flex",
+            flexDirection: "column",
+            mx: 3,
+            minWidth: 0,
           }}
-          content={
-            tab === 0 ? (
+        >
+          <ContentContainer>
+            {tab === 0 ? (
               <ProjectManagement />
             ) : tab === 1 ? (
               <PostTable />
             ) : (
-             <ProgressOverview />
-            )
-          }
-        />
-      </Box>
+              <ProgressOverview />
+            )}
+          </ContentContainer>
+        </Box>
       </Box>
     </PageWrapper>
   );


### PR DESCRIPTION
## 📌 개요

* 프로젝트 상세 페이지의 탭 레이아웃을 전면 수정하고 공통 레이아웃 컴포넌트를 분리하였습니다.

## 🛠️ 변경 사항

* 기존 TabsWithContent 제거
* 상단 버튼 그룹(ToggleButtonGroup) 기반으로 탭 전환 구조 변경
* ContentContainer 컴포넌트 신규 생성 및 공통 레이아웃 적용
* ProjectDetailPage 내부 레이아웃 정리 및 중복 코드 정돈

## ✅ 주요 체크 포인트

* [ ] 공통 레이아웃 적용에 따른 레이아웃 깨짐 여부
* [ ] 탭 전환시 정상적으로 화면 이동 및 데이터 표시 확인
* [ ] 프로젝트 삭제, 수정 동작 정상 여부 확인

## 🔁 테스트 결과

* 각 탭 전환시 정상 렌더링 확인
* 프로젝트 상세 진입 및 삭제/수정 기능 정상 작동 확인
* 공통 ContentContainer 적용 시 레이아웃 정상 유지 확인

## 🔗 연관된 이슈

* #201 

## 📑 레퍼런스

* 없음
