### PR TITLE
[feat]Vite 개발/운영 환경 분리 및 API 주소 설정(#206)

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# .env
-VITE_API_BASE_URL=http://localhost:8080

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+VITE_API_URL=http://localhost:8080
+VITE_ENV=development

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,2 @@
+VITE_API_URL=https://api.kbe-mywork.com
+VITE_ENV=production

--- a/src/api/api.js
+++ b/src/api/api.js
@@ -1,6 +1,6 @@
 import axios from "axios";
 
-const baseURL = import.meta.env.VITE_API_BASE_URL || "http://localhost:8080";
+const baseURL = import.meta.env.VITE_API_URL || "http://localhost:8080";
 
 const api = axios.create({
   baseURL,


### PR DESCRIPTION
## 📌 개요

- Vite 개발/운영 환경 분리 및 API 주소 설정

## 🛠️ 변경 사항

- `.env.development` / `.env.production` 파일 분리 및 API 주소 설정
- Axios 인스턴스에 `import.meta.env.VITE_API_BASE_URL` 적용

## ✅ 주요 체크 포인트

- [ ] 환경 변수에 따라 API 주소가 정확히 분기되어 사용하는지

## 🔁 테스트 결과

- [x] 개발 환경에서 `localhost:8080`으로 API 요청 정상 동작 확인
- [ ] 운영 환경에서 빌드 후 API 요청 동작 확인

## 🔗 연관된 이슈

- #206 

## 📑 레퍼런스

- [Vite 공식 문서 - 환경 변수](https://vitejs.dev/guide/env-and-mode.html)
