### PR TITLE
[feat]테이블 행 수정/삭제 버튼 ROLE_SYSTEM_ADMIN 권한일 때만 노출되도록 변경(#204)

### DIFF
--- a/src/components/common/customButton/CustomButton.jsx
+++ b/src/components/common/customButton/CustomButton.jsx
@@ -18,23 +18,23 @@ const StyledButton = styled(Button)(({ theme, kind }) => {
       "&:hover": {
         backgroundColor: theme.palette.primary.dark,
       },
-        "&.Mui-disabled": {
-       backgroundColor: theme.palette.primary.main,
-       color: theme.palette.primary.contrastText,
-       opacity: 0.5,              // 원하는 투명도 조절
-     },
+      "&.Mui-disabled": {
+        backgroundColor: theme.palette.primary.main,
+        color: theme.palette.primary.contrastText,
+        opacity: 0.5,
+      },
     },
     ghost: {
       backgroundColor: "transparent",
       color: theme.palette.text.primary,
-      border: `1px solid ${theme.palette.divider}`,
+      border: `1px solid ${theme.palette.text.primary}`,
       "&:hover": {
         backgroundColor: theme.palette.grey[100],
       },
       "&.Mui-disabled": {
-       color: theme.palette.action.disabled,
-       borderColor: theme.palette.action.disabledBackground,
-     },
+        color: theme.palette.action.disabled,
+        borderColor: theme.palette.action.disabledBackground,
+      },
     },
     danger: {
       backgroundColor: theme.palette.error.main,
@@ -43,10 +43,23 @@ const StyledButton = styled(Button)(({ theme, kind }) => {
         backgroundColor: theme.palette.error.dark,
       },
       "&.Mui-disabled": {
-       backgroundColor: theme.palette.error.main,
-       color: "#fff",
-       opacity: 0.5,
-     },
+        backgroundColor: theme.palette.error.main,
+        color: "#fff",
+        opacity: 0.5,
+      },
+    },
+    "ghost-danger": {
+      backgroundColor: "transparent",
+      color: theme.palette.error.main,
+      border: `1px solid ${theme.palette.error.main}`,
+      "&:hover": {
+        backgroundColor: theme.palette.error.light,
+      },
+      "&.Mui-disabled": {
+        color: theme.palette.error.main,
+        borderColor: theme.palette.error.main,
+        opacity: 0.5,
+      },
     },
   };
 

--- a/src/components/common/customTable/CustomTable.jsx
+++ b/src/components/common/customTable/CustomTable.jsx
@@ -22,11 +22,11 @@ import {
   Link,
   Button,
   LinearProgress,
-  IconButton,
 } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import { useSelector } from "react-redux";
 import dayjs from "dayjs";
+import CustomButton from "../customButton/CustomButton";
 import EditRoundedIcon from "@mui/icons-material/EditRounded";
 import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
 
@@ -43,6 +43,7 @@ export default function CustomTable({
   const { companyListOnlyIdName: companies = [] } = useSelector(
     (state) => state.company
   );
+  const userRole = useSelector((state) => state.auth.user.role);
   const theme = useTheme();
 
   // 정렬 설정
@@ -244,56 +245,35 @@ export default function CustomTable({
                   ))}
                   {/* 액션 컬럼 */}
                   <TableCell key="__actions__" align="center">
-                    <Stack direction="row" spacing={1} justifyContent="center">
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        sx={{
-                          borderRadius: "8px",
-                          color: theme.palette.grey[700],
-                          borderColor: theme.palette.grey[300],
-                          fontWeight: 600,
-                          px: 1.5,
-                          minWidth: 70,
-                          boxShadow: "none",
-                          textTransform: "none",
-                          "&:hover": {
-                            borderColor: theme.palette.primary.main,
-                            background: theme.palette.action.hover,
-                          },
-                        }}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onEdit?.(row);
-                        }}
+                    {userRole === "ROLE_SYSTEM_ADMIN" && (
+                      <Stack
+                        direction="row"
+                        spacing={1}
+                        justifyContent="center"
                       >
-                        수정
-                      </Button>
-                      <Button
-                        variant="outlined"
-                        size="small"
-                        sx={{
-                          borderRadius: "8px",
-                          color: theme.palette.status.error.main,
-                          borderColor: theme.palette.status.error.main,
-                          fontWeight: 600,
-                          px: 1.5,
-                          minWidth: 70,
-                          boxShadow: "none",
-                          textTransform: "none",
-                          "&:hover": {
-                            borderColor: theme.palette.status.error.dark,
-                            background: theme.palette.action.hover,
-                          },
-                        }}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onDelete?.(row);
-                        }}
-                      >
-                        삭제
-                      </Button>
-                    </Stack>
+                        <CustomButton
+                          kind="ghost"
+                          size="small"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onEdit?.(row);
+                          }}
+                        >
+                          수정
+                        </CustomButton>
+
+                        <CustomButton
+                          kind="ghost-danger"
+                          size="small"
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            onDelete?.(row);
+                          }}
+                        >
+                          삭제
+                        </CustomButton>
+                      </Stack>
+                    )}
                   </TableCell>
                 </TableRow>
               ))}


### PR DESCRIPTION
## 📌 개요

* 테이블 내 수정/삭제 버튼이 `ROLE_SYSTEM_ADMIN` 권한을 가진 사용자에게만 노출되도록 조건부 렌더링을 적용했습니다.
* CustomButton 컴포넌트에 `ghost-danger` 스타일을 추가하여 삭제 버튼에 적용했습니다.
* 기존 MUI Button을 모두 CustomButton으로 교체하였습니다.

---

## 🛠️ 변경 사항

* CustomButton에 `ghost-danger` 스타일 추가 (빨간 테두리)
* ghost 버튼의 테두리 색상을 글자 색상과 동일하게 변경
* CustomTable 내 수정/삭제 버튼을 CustomButton으로 교체
* Redux에서 사용자 권한(role) 값을 조회해 `ROLE_SYSTEM_ADMIN`일 때만 수정/삭제 버튼 노출되도록 조건부 렌더링 적용

---

## ✅ 주요 체크 포인트

* [ ] 사용자 권한(role)이 정확히 적용되어 버튼이 조건에 맞게 노출/비노출 되는지
* [ ] CustomButton의 스타일이 의도한 대로 적용되었는지 (특히 ghost-danger)
* [ ] 테이블 행 클릭 이벤트와 수정/삭제 버튼 이벤트가 충돌하지 않는지 확인

---

## 🔁 테스트 결과

* `ROLE_SYSTEM_ADMIN` 사용자로 로그인하여 수정/삭제 버튼이 정상 노출되는지 확인
* 다른 권한(`ROLE_MANAGER`, `ROLE_USER`)에서는 버튼이 보이지 않는 것을 확인
* 삭제 및 수정 동작 정상 작동 확인
* 버튼 hover 및 disabled 스타일 문제 없이 작동

---

## 🔗 연관된 이슈

* #204 

---

## 📑 레퍼런스

* [[MUI Button customization](https://mui.com/material-ui/customization/theme-components/#component-customization)](https://mui.com/material-ui/customization/theme-components/#component-customization)
* [[Redux useSelector 사용법](https://react-redux.js.org/api/hooks#useselector)](https://react-redux.js.org/api/hooks#useselector)