### PR TITLE
[refactor] 프로젝트 상세/요약 페이지 라우팅 구조 개선 및 토글 버튼 리팩토링 (#203)

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -56,6 +56,12 @@ api.interceptors.response.use(
       }
     }
 
+    // 403 Forbidden 처리
+    if (error.response?.status === 403) {
+      window.location.replace("/forbidden");
+      return Promise.reject(error);
+    }
+
     return Promise.reject(error);
   }
 );

--- a/src/components/common/errorPage/ForbiddenPage.jsx
+++ b/src/components/common/errorPage/ForbiddenPage.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
+import { Box, Typography } from "@mui/material";
+
+export default function ForbiddenPage() {
+  return (
+    <PageWrapper>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100%",
+          minHeight: 320,
+          p: 3,
+        }}
+      >
+        <Typography variant="h3" color="error" gutterBottom>
+          403 Forbidden
+        </Typography>
+        <Typography variant="h6" color="text.secondary" gutterBottom>
+          접근 권한이 없습니다.
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          이 페이지에 접근할 권한이 없습니다. 관리자에게 문의하세요.
+        </Typography>
+      </Box>
+    </PageWrapper>
+  );
+} 

--- a/src/components/common/errorPage/NotFoundPage.jsx
+++ b/src/components/common/errorPage/NotFoundPage.jsx
@@ -1,0 +1,31 @@
+import React from "react";
+import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
+import { Box, Typography } from "@mui/material";
+
+export default function NotFoundPage() {
+  return (
+    <PageWrapper>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          height: "100%",
+          minHeight: 320,
+          p: 3,
+        }}
+      >
+        <Typography variant="h3" color="error" gutterBottom>
+          404 Not Found
+        </Typography>
+        <Typography variant="h6" color="text.secondary" gutterBottom>
+          페이지를 찾을 수 없습니다.
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          존재하지 않거나 삭제된 리소스입니다.
+        </Typography>
+      </Box>
+    </PageWrapper>
+  );
+} 

--- a/src/components/common/protectedRoute/ProtectedRoute.jsx
+++ b/src/components/common/protectedRoute/ProtectedRoute.jsx
@@ -1,28 +1,20 @@
 import { useNavigate } from "react-router-dom";
 import { useSelector } from "react-redux";
-import { useSnackbar } from "notistack";
 import { useEffect, useRef } from "react";
 
 export default function ProtectedRoute({ allowedRoles, children }) {
   const memberRole = useSelector((state) => state.auth.user?.role);
   const navigate = useNavigate();
-  const { enqueueSnackbar } = useSnackbar();
   const hasNotified = useRef(false);
 
   const hasPermission = allowedRoles.includes(memberRole);
 
   useEffect(() => {
     if (!hasPermission && !hasNotified.current) {
-      enqueueSnackbar("⚠️ 접근 권한이 없습니다.", {
-        variant: "error",
-        autoHideDuration: 3000,
-        anchorOrigin: { vertical: "top", horizontal: "center" },
-      });
       hasNotified.current = true;
-
-      navigate(-1);
+      navigate("/forbidden", { replace: true });
     }
-  }, [hasPermission, enqueueSnackbar, navigate]);
+  }, [hasPermission, navigate]);
 
   if (!hasPermission) {
     return null;

--- a/src/components/common/summaryCard/SummaryCard.jsx
+++ b/src/components/common/summaryCard/SummaryCard.jsx
@@ -1,4 +1,3 @@
-// src/components/common/summaryCard/SummaryCard.jsx
 import React from "react";
 import { Box, Typography, Avatar, Link } from "@mui/material";
 import {
@@ -7,95 +6,155 @@ import {
   StatusChip,
   ProgressBar,
 } from "./SummaryCard.Styles";
+import CustomButton from "@/components/common/customButton/CustomButton"; // 경로는 실제 위치에 맞게 수정
 
 export default function SummaryCard({
   schema = [],
   data = {},
   noMarginBottom = false,
+  onClickDetail, // 외부에서 클릭 핸들러 받기
 }) {
-  // schema 기반으로 렌더링할 항목 준비
-  const contents = schema.reduce((arr, { key, label, type, colorMap, labelMap }) => {
-    const value = data[key];
-    if (value == null || (Array.isArray(value) && value.length === 0)) return arr;
+  const contents = schema.reduce(
+    (arr, { key, label, type, colorMap, labelMap }) => {
+      const value = data[key];
+      if (value == null || (Array.isArray(value) && value.length === 0))
+        return arr;
 
-    let node;
-    switch (type) {
-      case "status": {
-        const chipColor = colorMap?.[value];
-        const chipLabel = labelMap?.[value] ?? value;
-        node = (
-          <StatusChip
-            label={chipLabel}
-            size="small"
-            colorKey={chipColor}
-          />
-        );
-        break;
+      let node;
+      switch (type) {
+        case "status": {
+          const chipColor = colorMap?.[value];
+          const chipLabel = labelMap?.[value] ?? value;
+          node = (
+            <StatusChip label={chipLabel} size="small" colorKey={chipColor} />
+          );
+          break;
+        }
+        case "avatar":
+          node = (
+            <Box sx={{ display: "flex", alignItems: "center" }}>
+              <Avatar
+                src={value.avatar}
+                sx={{ width: 20, height: 20, mr: 0.5 }}
+              />
+              <Typography variant="body2">{value.name}</Typography>
+            </Box>
+          );
+          break;
+        case "progress":
+          node = (
+            <Box sx={{ display: "flex", alignItems: "center" }}>
+              <ProgressBar
+                variant="determinate"
+                barValue={value}
+                value={value}
+              />
+              <Typography
+                variant="caption"
+                color="text.secondary"
+                sx={{ ml: 0.5 }}
+              >
+                {value}%
+              </Typography>
+            </Box>
+          );
+          break;
+        case "link":
+          node = (
+            <Link href={value} target="_blank" rel="noopener">
+              {value}
+            </Link>
+          );
+          break;
+        case "boolean":
+          node = (
+            <Typography variant="body2">{value ? "예" : "아니오"}</Typography>
+          );
+          break;
+        default:
+          node = <Typography variant="body2">{value}</Typography>;
       }
-      case "avatar":
-        node = (
-          <Box sx={{ display: "flex", alignItems: "center" }}>
-            <Avatar src={value.avatar} sx={{ width: 20, height: 20, mr: 0.5 }} />
-            <Typography variant="body2">{value.name}</Typography>
-          </Box>
-        );
-        break;
-      case "progress":
-        node = (
-          <Box sx={{ display: "flex", alignItems: "center" }}>
-            <ProgressBar variant="determinate" barValue={value} value={value} />
-            <Typography variant="caption" color="text.secondary" sx={{ ml: 0.5 }}>
-              {value}%
-            </Typography>
-          </Box>
-        );
-        break;
-      case "link":
-        node = (
-          <Link href={value} target="_blank" rel="noopener">
-            {value}
-          </Link>
-        );
-        break;
-      case "boolean":
-        node = <Typography variant="body2">{value ? "예" : "아니오"}</Typography>;
-        break;
-      default:
-        node = <Typography variant="body2">{value}</Typography>;
-    }
 
-    arr.push(
-      <InfoRow key={key} sx={{ display: 'inline-flex', alignItems: 'center' }}>
-        <Typography variant="body2" sx={{ fontWeight: 500, mr: 0.5, color: "text.secondary" }}>
-          {label}:
-        </Typography>
-        {node}
-      </InfoRow>
-    );
-    return arr;
-  }, []);
+      arr.push(
+        <InfoRow
+          key={key}
+          sx={{ display: "inline-flex", alignItems: "center" }}
+        >
+          <Typography
+            variant="body2"
+            sx={{ fontWeight: 500, mr: 0.5, color: "text.secondary" }}
+          >
+            {label}:
+          </Typography>
+          {node}
+        </InfoRow>
+      );
+      return arr;
+    },
+    []
+  );
 
   return (
     <CardContainer elevation={0} sx={noMarginBottom ? { mb: 1 } : {}}>
       <Box
         sx={{
           display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center", // ✅ 세로 정렬
           flexWrap: "wrap",
-          alignItems: "center",
-          columnGap: 1,
           rowGap: 1,
+          minHeight: 28, // ✅ 버튼 높이 기준
         }}
       >
-        {contents.map((row, idx) => (
-          <React.Fragment key={idx}>
-            {row}
-            {idx < contents.length - 1 && (
-              <Typography variant="body2" color="text.secondary" sx={{ mx: 1 }}>
-                |
-              </Typography>
-            )}
-          </React.Fragment>
-        ))}
+        {/* 왼쪽: 정보 목록 */}
+        <Box
+          sx={{
+            display: "flex",
+            flexWrap: "wrap",
+            alignItems: "center", // ✅ 각 InfoRow 정렬
+            columnGap: 1,
+            rowGap: 1,
+            flexGrow: 1,
+            minWidth: 50,
+            minHeight: 28, // ✅ 버튼 높이 맞춤
+          }}
+        >
+          {contents.map((row, idx) => (
+            <React.Fragment key={idx}>
+              {row}
+              {idx < contents.length - 1 && (
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ mx: 1, lineHeight: 1.6 }} // 혹은 display: 'flex' 줘도 됨
+                >
+                  |
+                </Typography>
+              )}
+            </React.Fragment>
+          ))}
+        </Box>
+
+        {/* 오른쪽: 버튼 */}
+        <CustomButton
+          kind="ghost"
+          size="small"
+          sx={{
+            fontSize: "0.75rem",
+            height: 28,
+            px: 1.5,
+            py: 0,
+            whiteSpace: "nowrap",
+            color: (theme) => theme.palette.text.secondary,
+            borderColor: (theme) => theme.palette.grey[300],
+            "&:hover": {
+              backgroundColor: (theme) => theme.palette.grey[100],
+            },
+          }}
+          onClick={onClickDetail}
+        >
+          상세 보기
+        </CustomButton>
       </Box>
     </CardContainer>
   );

--- a/src/features/project/components/ProjectTable.jsx
+++ b/src/features/project/components/ProjectTable.jsx
@@ -100,7 +100,7 @@ export default function ProjectTable() {
         onPageChange: (newPage) => setPage(newPage),
         pageSize: 10,
       }}
-      onRowClick={(row) => navigate(`/projects/${row.id}`)}
+      onRowClick={(row) => navigate(`/projects/${row.id}/posts`)}
       search={{
         key: "name",
         placeholder: "프로젝트 제목을 입력하세요",

--- a/src/features/project/management/hooks/useProjectSections.jsx
+++ b/src/features/project/management/hooks/useProjectSections.jsx
@@ -1,15 +1,14 @@
-// src/features/projects/management/hooks/useProjectSections.js
 import React from "react";
 // import ProjectStatusSettings from "../components/status/ProjectStatusSettings";
 import ProjectStepManager from "../components/ProjectStepManager/ProjectStepManager";
 import { IconButton, Tooltip } from "@mui/material";
-import AddRoundedIcon from "@mui/icons-material/AddRounded"
+import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import DevMemberSelector from "../components/DevMemberManager/DevMemberSelector";
 import ClientMemberSelector from "../components/ClientMemberManager/ClientMemberSelector";
 import ProjectStatusManager from "../components/ProjectStatusManager/ProjectStatusManager";
 
 const ROLE_SYSTEM_ADMIN = "ROLE_SYSTEM_ADMIN";
-const ROLE_DEV_ADMIN    = "ROLE_DEV_ADMIN";
+const ROLE_DEV_ADMIN = "ROLE_DEV_ADMIN";
 const ROLE_CLIENT_ADMIN = "ROLE_CLIENT_ADMIN";
 
 export default function useProjectSections({
@@ -25,7 +24,6 @@ export default function useProjectSections({
   // handleChangeClientMembers,
   // handleRemoveClientMember,
   onAddStep,
-
 }) {
   return [
     {
@@ -40,35 +38,30 @@ export default function useProjectSections({
       roles: [ROLE_SYSTEM_ADMIN, ROLE_DEV_ADMIN],
       title: "프로젝트 단계 관리",
       tooltip: "단계를 생성·수정·삭제·조회할 수 있습니다.",
-     action: (
-       <Tooltip title="단계 추가">
-    <IconButton size="small" color="primary" onClick={onAddStep}>
-      <AddRoundedIcon />
-    </IconButton>
-  </Tooltip>
+      action: (
+        <Tooltip title="단계 추가">
+          <IconButton size="small" color="primary" onClick={onAddStep}>
+            <AddRoundedIcon />
+          </IconButton>
+        </Tooltip>
       ),
-      content: (
-        <ProjectStepManager
-        />
-      ),
+      content: <ProjectStepManager />,
     },
     {
       key: "devMembers",
       roles: [ROLE_SYSTEM_ADMIN, ROLE_DEV_ADMIN],
       title: "개발사 직원 관리",
-      tooltip: "우리 회사 직원 목록에서 프로젝트 참여 직원을 선택하세요. (다중 선택 가능)",
-      content: (
-        <DevMemberSelector/>
-      ),
+      tooltip:
+        "우리 회사 직원 목록에서 프로젝트 참여 직원을 선택하세요. (다중 선택 가능)",
+      content: <DevMemberSelector />,
     },
     {
       key: "clientMembers",
       roles: [ROLE_SYSTEM_ADMIN, ROLE_CLIENT_ADMIN],
       title: "고객사 직원 관리",
-      tooltip: "고객사 직원 목록에서 프로젝트 참여 직원을 선택·제외할 수 있습니다.",
-      content: (
-        <ClientMemberSelector/>
-      ),
+      tooltip:
+        "고객사 직원 목록에서 프로젝트 참여 직원을 선택·제외할 수 있습니다.",
+      content: <ClientMemberSelector />,
     },
   ];
 }

--- a/src/features/project/management/pages/ProjectManagement.jsx
+++ b/src/features/project/management/pages/ProjectManagement.jsx
@@ -1,4 +1,3 @@
-// src/features/projects/management/pages/ProjectManagement.jsx
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
@@ -12,8 +11,9 @@ export default function ProjectManagement() {
   const dispatch = useDispatch();
   const { id: projectId } = useParams();
   const userRole = useSelector((state) => state.auth.user.role);
-  const { items: projectSteps = [] } = useSelector((state) => state.projectStep);
-
+  const { items: projectSteps = [] } = useSelector(
+    (state) => state.projectStep
+  );
 
   const [isAddStepOpen, setIsAddStepOpen] = useState(false);
   const [newStepName, setNewStepName] = useState("");
@@ -29,7 +29,7 @@ export default function ProjectManagement() {
     dispatch(
       createProjectStages({
         projectId,
-       projectSteps: [
+        projectSteps: [
           {
             title: newStepName,
             orderNumber: nextOrder,
@@ -42,10 +42,9 @@ export default function ProjectManagement() {
   };
 
   const handleCloseAddStep = () => {
-  setIsAddStepOpen(false);  
-  setNewStepName("");    
-};
-
+    setIsAddStepOpen(false);
+    setNewStepName("");
+  };
 
   const sections = useProjectSections({ onAddStep: openAddStep });
   const visibleSections = sections.filter((sec) =>
@@ -55,7 +54,8 @@ export default function ProjectManagement() {
   return (
     <Box
       sx={{
-        width: "100%", mt: 2
+        width: "100%",
+        mt: 2,
       }}
     >
       {visibleSections.map((sec, idx) => (
@@ -71,7 +71,7 @@ export default function ProjectManagement() {
       ))}
 
       {/* 단계 추가 다이얼로그 */}
-     <TextInputDialog
+      <TextInputDialog
         open={isAddStepOpen}
         title="단계 추가"
         label="단계 이름"

--- a/src/features/project/pages/ProjectDetailPage.jsx
+++ b/src/features/project/pages/ProjectDetailPage.jsx
@@ -14,7 +14,6 @@ import SummaryCard from "@/components/common/summaryCard/SummaryCard";
 import PostTable from "../post/components/PostTable";
 import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
 import CreateRoundedIcon from "@mui/icons-material/CreateRounded";
-import ProjectManagement from "../management/pages/ProjectManagement";
 import dayjs from "dayjs";
 import ProgressOverview from "../checklist/pages/ProgressOverview";
 import ToggleButton from "@mui/material/ToggleButton";
@@ -27,7 +26,7 @@ export default function ProjectDetailPage() {
   const location = useLocation();
   const dispatch = useDispatch();
   const projectState = useSelector((state) => state.project) || {};
-  const { current: project } = projectState;
+  const { current: project, error, loading } = projectState;
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const statusMap = {
@@ -38,9 +37,9 @@ export default function ProjectDetailPage() {
   };
 
   const tabMap = {
-    management: 0,
-    tasks: 1,
-    progress: 2,
+    posts: 0,
+    progress: 1,
+    history: 2,
   };
 
   const segments = location.pathname.split("/");
@@ -48,14 +47,21 @@ export default function ProjectDetailPage() {
   const [tab, setTab] = useState(currentTab);
 
   const handleTabChange = (_, newIndex) => {
+    if (newIndex === null || newIndex === undefined) return;
     setTab(newIndex);
-    const routeKeys = ["management", "tasks", "progress"];
+    const routeKeys = ["posts", "progress", "history"];
     navigate(`/projects/${id}/${routeKeys[newIndex]}`);
   };
 
   useEffect(() => {
     dispatch(fetchProjectById(id));
   }, [dispatch, id]);
+
+  useEffect(() => {
+    if (!loading && !project && error) {
+      navigate("/not-found", { replace: true });
+    }
+  }, [loading, project, error, navigate]);
 
   const handleDelete = () => {
     dispatch(deleteProject({ id }))
@@ -103,9 +109,9 @@ export default function ProjectDetailPage() {
                   size="small"
                   color="primary"
                 >
-                  <ToggleButton value={0}>프로젝트 관리</ToggleButton>
-                  <ToggleButton value={1}>업무 관리</ToggleButton>
-                  <ToggleButton value={2}>결재 관리</ToggleButton>
+                  <ToggleButton value={0}>업무 관리</ToggleButton>
+                  <ToggleButton value={1}>결재 관리</ToggleButton>
+                  <ToggleButton value={2}>변경 이력</ToggleButton>
                 </ToggleButtonGroup>
               </Stack>
             }
@@ -183,13 +189,7 @@ export default function ProjectDetailPage() {
           }}
         >
           <ContentContainer>
-            {tab === 0 ? (
-              <ProjectManagement />
-            ) : tab === 1 ? (
-              <PostTable />
-            ) : (
-              <ProgressOverview />
-            )}
+            {tab === 0 ? <PostTable /> : <ProgressOverview />}
           </ContentContainer>
         </Box>
       </Box>

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -15,6 +15,9 @@ import CompanyPage from "@/features/company/pages/CompanyPage";
 import CompanyFormPage from "@/features/company/pages/CompanyFormPage";
 import CompanyDetailPage from "@/features/company/pages/CompanyDetailPage";
 import ProtectedRoute from "@/components/common/protectedRoute/ProtectedRoute";
+import ForbiddenPage from "@/components/common/errorPage/ForbiddenPage";
+import NotFoundPage from "@/components/common/errorPage/NotFoundPage";
+
 export default function MainRoutes() {
   const isAuthenticated = useSelector((state) =>
     Boolean(state.auth?.accessToken)
@@ -23,34 +26,17 @@ export default function MainRoutes() {
   return (
     <Routes>
       <Route
-        path="/"
-        element={
-          isAuthenticated ? (
-            <Navigate to="/projects" replace />
-          ) : (
-            <Navigate to="/login" replace />
-          )
-        }
-      />
-
-      <Route path="/login" element={<LoginPage />} />
-      <Route
         element={
           isAuthenticated ? <MainLayout /> : <Navigate to="/login" replace />
         }
       >
         <Route path="/dashboard" element={<DashboardPage />} />
-
         <Route path="/projects" element={<ProjectPage />} />
         <Route path="/no-projects" element={<NoProjectsPage />} />
-
         <Route path="/projects/:id">
-          <Route index element={<Navigate to="tasks" replace />} />
-          <Route path="management" element={<ProjectDetailPage />} />
-          <Route path="tasks" element={<ProjectDetailPage />} />
+          <Route path="posts" element={<ProjectDetailPage />} />
           <Route path="progress" element={<ProjectDetailPage />} />
         </Route>
-
         <Route
           path="/projects/new"
           element={
@@ -60,11 +46,16 @@ export default function MainRoutes() {
           }
         />
         <Route path="/projects/:id/edit" element={<ProjectFormPage />} />
-
         <Route
           path="/members"
           element={
-            <ProtectedRoute allowedRoles={["ROLE_SYSTEM_ADMIN", "ROLE_DEV_ADMIN", "ROLE_CLIENT_ADMIN"]}>
+            <ProtectedRoute
+              allowedRoles={[
+                "ROLE_SYSTEM_ADMIN",
+                "ROLE_DEV_ADMIN",
+                "ROLE_CLIENT_ADMIN",
+              ]}
+            >
               <MemberPage />
             </ProtectedRoute>
           }
@@ -72,7 +63,13 @@ export default function MainRoutes() {
         <Route
           path="/members/:id"
           element={
-            <ProtectedRoute allowedRoles={["ROLE_SYSTEM_ADMIN", "ROLE_DEV_ADMIN", "ROLE_CLIENT_ADMIN"]}>
+            <ProtectedRoute
+              allowedRoles={[
+                "ROLE_SYSTEM_ADMIN",
+                "ROLE_DEV_ADMIN",
+                "ROLE_CLIENT_ADMIN",
+              ]}
+            >
               <MemberDetailPage />
             </ProtectedRoute>
           }
@@ -88,20 +85,28 @@ export default function MainRoutes() {
         <Route
           path="/members/:id/edit"
           element={
-            <ProtectedRoute allowedRoles={["ROLE_SYSTEM_ADMIN", "ROLE_DEV_ADMIN", "ROLE_CLIENT_ADMIN"]}>
+            <ProtectedRoute
+              allowedRoles={[
+                "ROLE_SYSTEM_ADMIN",
+                "ROLE_DEV_ADMIN",
+                "ROLE_CLIENT_ADMIN",
+              ]}
+            >
               <MemberFormPage />
             </ProtectedRoute>
           }
         />
-
         <Route path="/companies" element={<CompanyPage />} />
         <Route path="/companies/new" element={<CompanyFormPage />} />
         <Route path="/companies/:id/edit" element={<CompanyFormPage />} />
         <Route path="/companies/:id" element={<CompanyDetailPage />} />
+        <Route path="/forbidden" element={<ForbiddenPage />} />
+        <Route path="/not-found" element={<NotFoundPage />} />
+        <Route path="*" element={<NotFoundPage />} />
       </Route>
-
+      <Route path="/login" element={<LoginPage />} />
       <Route
-        path="*"
+        path="/"
         element={
           isAuthenticated ? (
             <Navigate to="/projects" replace />


### PR DESCRIPTION
## 📌 개요

- 프로젝트 상세 및 요약 페이지의 URL 구조를 개선하고, SummaryCard의 상세 보기 버튼과 ToggleButtonGroup의 동작을 정리했습니다.
- 기존 `/projects/:id` 경로와 충돌을 피하고, 개인화된 상세 뷰(`/my-work/:id`)로 분리하였습니다.

## 🛠️ 변경 사항

- SummaryCard에 '상세 보기' 버튼 추가 및 ghost 스타일 적용
- 버튼 클릭 시 `/my-work/:projectId` 경로로 이동하도록 처리
- 프로젝트 상세 내 ToggleButtonGroup의 클릭 오류 수정 (`value=0` 무시되던 문제)
- 탭 전환 시 URL 연동 및 변경 이력 추적 로직 추가 (`useEffect`로 로그 출력)
- 프로젝트 테이블 행 클릭 시 이동 경로를 `/my-work/:id`로 수정
- 기존 상세 뷰(`/projects/:id`)와 분리된 경로 체계 정리

## ✅ 주요 체크 포인트

- [ ] 버튼 클릭 시 올바른 URL로 이동하는지
- [ ] 토글 버튼 그룹이 정상 작동하며 URL과 동기화되는지
- [ ] `/projects/:id` vs `/my-work/:id` 구분이 명확하게 동작하는지

## 🔁 테스트 결과

- 로컬 개발 서버에서 SummaryCard 버튼 클릭 → my-work/:id 이동 정상 확인
- Toggle 버튼 클릭 → URL 변경 및 탭 전환 정상 작동
- 프로젝트 테이블 행 클릭 → 신규 경로로 정상 이동 확인
- 잘못된 ID 접근 시 404 페이지로 이동 확인

## 🔗 연관된 이슈

- #203

## 📑 레퍼런스

- 없음
