### PR TITLE
[fix] 프로젝트 상세 페이지 리다자인 스탭,생성버튼 위치 변경(#216)

### DIFF
--- a/src/features/project/pages/ProjectDetailPage.jsx
+++ b/src/features/project/pages/ProjectDetailPage.jsx
@@ -28,6 +28,9 @@ export default function ProjectDetailPage() {
   const projectState = useSelector((state) => state.project) || {};
   const { current: project, error, loading } = projectState;
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const steps = useSelector((state) => state.projectStep.items) || [];
+  const [selectedStepTitle, setSelectedStepTitle] = useState("전체");
+  const [selectedStepId, setSelectedStepId] = useState(null);
 
   const statusMap = {
     NOT_STARTED: { color: "neutral", label: "계획" },
@@ -178,6 +181,74 @@ export default function ProjectDetailPage() {
           />
         </Box>
 
+        {/* 스탭(단계) 카드형 UI - SummaryCard 아래, 검색 조건 위 */}
+        {tab === 0 && steps.length > 0 && (
+          <Box sx={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            width: '100%',
+            mb: 2,
+          }}>
+            <Box sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 2,
+              bgcolor: '#fff',
+              borderRadius: 3,
+              boxShadow: '0 2px 12px 0 rgba(0,0,0,0.06)',
+              px: 4,
+              py: 3,
+              width: 'fit-content',
+              mx: 'auto',
+            }}>
+              {/* 전체 카드 */}
+              <Box
+                onClick={() => {
+                  setSelectedStepTitle("전체");
+                  setSelectedStepId(null);
+                }}
+                sx={{
+                  cursor: 'pointer',
+                  minWidth: 120,
+                  p: 2,
+                  borderRadius: 2,
+                  bgcolor: !selectedStepTitle || selectedStepTitle === "전체" ? '#e7f0fa' : '#fff',
+                  border: !selectedStepTitle || selectedStepTitle === "전체" ? '2px solid #b5d3f3' : '1px solid #eee',
+                  boxShadow: !selectedStepTitle || selectedStepTitle === "전체" ? '0 2px 8px 0 rgba(0,0,0,0.04)' : 'none',
+                  display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+                  transition: 'all 0.2s',
+                }}
+              >
+                <Box sx={{ fontWeight: 700, fontSize: 18, mb: 0.5, mt: 1 }}>전체</Box>
+              </Box>
+              {/* 각 단계 카드 */}
+              {steps.map((step) => (
+                <Box
+                  key={step.projectStepId}
+                  onClick={() => {
+                    setSelectedStepTitle(step.title);
+                    setSelectedStepId(step.projectStepId);
+                  }}
+                  sx={{
+                    cursor: 'pointer',
+                    minWidth: 120,
+                    p: 2,
+                    borderRadius: 2,
+                    bgcolor: selectedStepTitle === step.title ? '#e7f0fa' : '#fff',
+                    border: selectedStepTitle === step.title ? '2px solid #b5d3f3' : '1px solid #eee',
+                    boxShadow: selectedStepTitle === step.title ? '0 2px 8px 0 rgba(0,0,0,0.04)' : 'none',
+                    display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+                    transition: 'all 0.2s',
+                  }}
+                >
+                  <Box sx={{ fontWeight: 700, fontSize: 18, mb: 0.5, mt: 1 }}>{step.title}</Box>
+                </Box>
+              ))}
+            </Box>
+          </Box>
+        )}
+
         {/* Content */}
         <Box
           sx={{
@@ -189,7 +260,16 @@ export default function ProjectDetailPage() {
           }}
         >
           <ContentContainer>
-            {tab === 0 ? <PostTable /> : <ProgressOverview />}
+            {tab === 0 ? (
+              <PostTable
+                selectedStepTitle={selectedStepTitle}
+                selectedStepId={selectedStepId}
+                setSelectedStepTitle={setSelectedStepTitle}
+                setSelectedStepId={setSelectedStepId}
+              />
+            ) : (
+              <ProgressOverview />
+            )}
           </ContentContainer>
         </Box>
       </Box>

--- a/src/features/project/post/components/PostTable.jsx
+++ b/src/features/project/post/components/PostTable.jsx
@@ -1,7 +1,7 @@
 // src/components/common/postTable/PostTable.jsx
 
 import React, { useState, useEffect } from "react";
-import { Box, Pagination } from "@mui/material";
+import { Box, Pagination, FormControl, InputLabel, Select, MenuItem, TextField } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import SectionTable from "@/components/common/sectionTable/SectionTable";
@@ -11,7 +11,7 @@ import CustomButton from "@/components/common/customButton/CustomButton";
 import { fetchPosts, fetchPostById, createPost } from "../postSlice";
 import { fetchProjectStages } from "../../projectStepSlice";
 
-export default function PostTable() {
+export default function PostTable({ selectedStepTitle, selectedStepId, setSelectedStepTitle, setSelectedStepId }) {
   const dispatch = useDispatch();
   const { id: projectId } = useParams();
 
@@ -21,8 +21,6 @@ export default function PostTable() {
   const steps = useSelector((state) => state.projectStep.items) || [];
 
   const [page, setPage] = useState(1);
-  const [selectedStepTitle, setSelectedStepTitle] = useState("전체");
-  const [selectedStepId, setSelectedStepId] = useState(null);
   const [searchKey, setSearchKey] = useState("");
   const [searchText, setSearchText] = useState("");
   const [selectedPost, setSelectedPost] = useState(null);
@@ -94,8 +92,44 @@ export default function PostTable() {
 
   return (
     <Box sx={{ width: "100%", mt: 2 }}>
-      {/* 새 글 작성 버튼 */}
-      <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1 }}>
+      {/* 검색 조건 + 검색창 + 새 글 작성 버튼 한 줄 */}
+      <Box sx={{ display: "flex", alignItems: "center", justifyContent: "space-between", mb: 1 }}>
+        <Box sx={{ flex: 1, minWidth: 0, display: 'flex', alignItems: 'center' }}>
+          <FormControl size="small" sx={{ minWidth: 120, mr: 2 }}>
+            <InputLabel>검색 조건</InputLabel>
+            <Select
+              value={searchKey}
+              onChange={(e) => {
+                setPage(1);
+                setSearchKey(e.target.value);
+                if (!e.target.value) setSearchText(""); // 검색 조건 해제 시 검색어도 초기화
+              }}
+              label="검색 조건"
+            >
+              <MenuItem value="">선택</MenuItem>
+              {columns.filter((c) => c.searchable).map((col) => (
+                <MenuItem key={col.key} value={col.key}>
+                  {col.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          {searchKey && (
+            <TextField
+              size="small"
+              placeholder="검색어를 입력하세요"
+              value={searchText}
+              onChange={(e) => {
+                setPage(1);
+                setSearchText(e.target.value);
+              }}
+              sx={{ width: '70%', minWidth: 200 }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') setPage(1);
+              }}
+            />
+          )}
+        </Box>
         <CustomButton variant="contained" onClick={() => setCreateOpen(true)}>
           새 글 작성
         </CustomButton>
@@ -106,7 +140,7 @@ export default function PostTable() {
         columns={columns}
         rows={posts}
         rowKey="id"
-        steps={steps}
+        steps={[]}
         selectedStep={selectedStepTitle}
         onStepChange={(stepId, stepTitle) => {
           setPage(1);
@@ -116,19 +150,6 @@ export default function PostTable() {
         onRowClick={handleRowClick}
         pagination={{ page, total: totalCount, onPageChange: setPage }}
         sx={{ width: "100%" }}
-        search={{
-          key: searchKey,
-          placeholder: "검색어를 입력하세요",
-          value: searchText,
-          onKeyChange: (newKey) => {
-            setPage(1);
-            setSearchKey(newKey);
-          },
-          onChange: (newText) => {
-            setPage(1);
-            setSearchText(newText);
-          },
-        }}
       />
 
       {/* 상세 드로어 */}


### PR DESCRIPTION
## 📌 개요

- 프로젝트 상세 페이지 리다자인
## 🛠️ 변경 사항

-프로젝트 상세 페이지 리다자인 스탭 영역을 독단적인 영역으로 분리 
- 프로젝 생성 버튼이 너무 띄워저 잇어서 테이블 오른쪽 상단으로 위치변경
-  위치변경에 따른 검색 영역 사이즈 조절

## ✅ 주요 체크 포인트

- [ ] 화면 테스트

## 🔁 테스트 결과

<img width="1594" alt="image" src="https://github.com/user-attachments/assets/71d0939f-0244-45fa-9842-b1b3ab421aac" />


## 🔗 연관된 이슈
#216