### PR TITLE
회사 상세 정보에 직원리스트 호출 API 변경 #220

### DIFF
--- a/src/api/member.js
+++ b/src/api/member.js
@@ -82,3 +82,12 @@ export function findMembers(page, keyword, keywordType) {
 export function getMemberProjects(memberId) {
   return api.get(`/api/member/${memberId}/myProjects`);
 }
+
+/**
+ * 회사별 직원 목록 조회 (GET /api/companies/{companyId}/members)
+ * @param {string} companyId - 조회할 회사 UUID
+ * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<MemberListWebResponse>
+ */
+export function getCompanyMembersByCompanyId(companyId) {
+  return api.get(`/api/companies/${companyId}/members`);
+}

--- a/src/features/company/pages/CompanyDetailPage.jsx
+++ b/src/features/company/pages/CompanyDetailPage.jsx
@@ -24,7 +24,7 @@ import {
   fetchCompanyById,
   deleteCompany,
 } from "@/features/company/companySlice";
-import { getCompanyMembers } from "@/api/member";
+import { getCompanyMembersByCompanyId } from "@/api/member";
 import { useTheme } from "@mui/material/styles";
 
 export default function CompanyDetailPage() {
@@ -50,13 +50,13 @@ export default function CompanyDetailPage() {
   useEffect(() => {
     if (!company?.companyId) return;
     setLoadingMembers(true);
-    getCompanyMembers(company.companyId, page, searchText)
+    getCompanyMembersByCompanyId(company.companyId)
       .then((res) => {
         setMembers(res.data.data.members);
         setTotalCount(res.data.data.totalCount);
       })
       .finally(() => setLoadingMembers(false));
-  }, [company?.companyId, page, searchText]);
+  }, [company?.companyId]);
 
   const handleDelete = async () => {
     await dispatch(deleteCompany(id)).unwrap();


### PR DESCRIPTION
## 📌 개요

-회사 상세 정보에 직원리스트 호출 API 변경 #220
## 🛠️ 변경 사항

-  api  호출을 변경 

## ✅ 주요 체크 포인트

- [ ] 기존에 회사상세에 멤버 조회시 모든유저를 노출해주고있었던게 정상적으로 내 회사직원만 나오게 수정

## 🔁 테스트 결과

- 화면에서 테스트

![image](https://github.com/user-attachments/assets/f85435db-70b1-4d70-86d9-2982c6c8fe27)

## 🔗 연관된 이슈
#220 