### PR TITLE
feat: 대시보드 페이지에서 프로젝트 요약 및 마감 임박 프로젝트 목록 표시 기능 구현 (#223)

### DIFF
--- a/src/api/dashboard.js
+++ b/src/api/dashboard.js
@@ -1,0 +1,20 @@
+// src/api/dashboard.js
+
+import api from "./api";
+
+/**
+ * 대시보드 요약 정보 조회 (전체, 진행중, 완료 등)
+ */
+export const getDashboardTotalSummary = () => {
+  return api.get("/api/dashboard/totalSummery");
+};
+
+/**
+ * 마감 임박 프로젝트 조회 (페이지 기반)
+ * @param {number} page - 1부터 시작하는 페이지 번호
+ */
+export function getNearDeadlineProjects(params) {
+  return api.get("/api/dashboard/projects/near-deadline", {
+    params,
+  });
+}

--- a/src/features/dashboard/DashboardSlice.js
+++ b/src/features/dashboard/DashboardSlice.js
@@ -1,0 +1,94 @@
+// src/features/dashboard/dashboardSlice.js
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import * as dashboardAPI from "@/api/dashboard";
+
+// 대시보드 총 요약 정보 조회
+export const fetchDashboardSummary = createAsyncThunk(
+  "dashboard/fetchSummary",
+  async (_, thunkAPI) => {
+    try {
+      const response = await dashboardAPI.getDashboardTotalSummary();
+      return response.data.data;
+    } catch (err) {
+      return thunkAPI.rejectWithValue(
+        err.response?.data || "대시보드 요약 정보 조회 실패"
+      );
+    }
+  }
+);
+
+export const fetchNearDeadlineProjects = createAsyncThunk(
+  "dashboard/fetchNearDeadlineProjects",
+  async ({ page }, thunkAPI) => {
+    try {
+      const response = await dashboardAPI.getNearDeadlineProjects({ page });
+      const { projects, totalCount } = response.data.data;
+      return { projects, totalCount, currentPage: page };
+    } catch (err) {
+      return thunkAPI.rejectWithValue(
+        err.response?.data || "마감 임박 프로젝트 목록 조회 실패"
+      );
+    }
+  }
+);
+
+const dashboardSlice = createSlice({
+  name: "dashboard",
+  initialState: {
+    summary: null,
+    summaryLoading: false,
+    summaryError: null,
+
+    nearDeadline: [],
+    nearDeadlineTotalCount: 0,
+    nearDeadlineCurrentPage: 1,
+    nearDeadlineLoading: false,
+    nearDeadlineError: null,
+  },
+  reducers: {
+    clearDashboardState(state) {
+      state.summary = null;
+      state.summaryError = null;
+
+      state.nearDeadline = [];
+      state.nearDeadlineError = null;
+      state.nearDeadlineTotalCount = 0;
+      state.nearDeadlineCurrentPage = 1;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // 총 요약 정보
+      .addCase(fetchDashboardSummary.pending, (state) => {
+        state.summaryLoading = true;
+        state.summaryError = null;
+      })
+      .addCase(fetchDashboardSummary.fulfilled, (state, action) => {
+        state.summaryLoading = false;
+        state.summary = action.payload;
+      })
+      .addCase(fetchDashboardSummary.rejected, (state, action) => {
+        state.summaryLoading = false;
+        state.summaryError = action.payload;
+      })
+
+      // 마감 임박 프로젝트
+      .addCase(fetchNearDeadlineProjects.pending, (state) => {
+        state.nearDeadlineLoading = true;
+        state.nearDeadlineError = null;
+      })
+      .addCase(fetchNearDeadlineProjects.fulfilled, (state, action) => {
+        state.nearDeadlineLoading = false;
+        state.nearDeadline = action.payload.projects;
+        state.nearDeadlineTotalCount = action.payload.totalCount;
+        state.nearDeadlineCurrentPage = action.payload.currentPage;
+      })
+      .addCase(fetchNearDeadlineProjects.rejected, (state, action) => {
+        state.nearDeadlineLoading = false;
+        state.nearDeadlineError = action.payload;
+      });
+  },
+});
+
+export const { clearDashboardState } = dashboardSlice.actions;
+export default dashboardSlice.reducer;

--- a/src/features/dashboard/pages/DashboardPage.jsx
+++ b/src/features/dashboard/pages/DashboardPage.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from "react";
+import React, { useMemo, useState, useEffect } from "react";
 import dayjs from "dayjs";
 import {
   Box,
@@ -6,95 +6,42 @@ import {
   Stack,
   Pagination,
   Divider,
-  Button,
+  Chip,
 } from "@mui/material";
 import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
 import PageHeader from "@/components/layouts/pageHeader/PageHeader";
-
-// 하드코딩 데이터
-const dummyProjects = [
-  {
-    id: 1,
-    name: "프로젝트 A",
-    startAt: "2024-06-01",
-    endAt: "2024-06-30",
-    postCount: 15,
-  },
-  {
-    id: 2,
-    name: "프로젝트 B",
-    startAt: "2024-06-10",
-    endAt: "2024-06-20",
-    postCount: 3,
-  },
-  {
-    id: 3,
-    name: "프로젝트 C",
-    startAt: "2024-06-05",
-    endAt: "2024-06-19",
-    postCount: 9,
-  },
-  {
-    id: 4,
-    name: "프로젝트 D",
-    startAt: "2024-06-01",
-    endAt: "2024-07-05",
-    postCount: 30,
-  },
-  {
-    id: 5,
-    name: "프로젝트 E",
-    startAt: "2024-05-15",
-    endAt: "2024-06-15",
-    postCount: 6,
-  },
-  {
-    id: 6,
-    name: "프로젝트 F",
-    startAt: "2024-05-10",
-    endAt: "2024-06-10",
-    postCount: 12,
-  },
-];
+import { useDispatch, useSelector } from "react-redux";
+import {
+  fetchDashboardSummary,
+  fetchNearDeadlineProjects,
+} from "@/features/dashboard/dashboardSlice";
 
 export default function DashboardPage() {
-  const projects = dummyProjects;
-  const now = dayjs();
-  const DUE_LIMIT = 5;
+  const dispatch = useDispatch();
+  const dashboard = useSelector((state) => state.dashboard) || {};
+  const {
+    summary,
+    nearDeadline = [],
+    nearDeadlineTotalCount = 0,
+    loading = false,
+  } = dashboard;
 
-  const totalCount = projects.length;
-  const inProgressCount = projects.filter(
-    (p) => dayjs(p.startAt).isBefore(now) && dayjs(p.endAt).isAfter(now)
-  ).length;
-  const expiredCount = projects.filter((p) =>
-    dayjs(p.endAt).isBefore(now)
-  ).length;
-
-  const dueProjects = useMemo(() => {
-    return projects
-      .filter((p) => {
-        const diff = dayjs(p.endAt).diff(now, "day");
-        return diff >= 0 && diff <= DUE_LIMIT;
-      })
-      .sort((a, b) => dayjs(a.endAt) - dayjs(b.endAt));
-  }, [projects]);
-
-  const hotProjects = useMemo(() => {
-    return [...projects].sort((a, b) => b.postCount - a.postCount);
-  }, [projects]);
+  const safeSummary = summary || {
+    totalCount: 0,
+    inProgressCount: 0,
+    completedCount: 0,
+  };
 
   const [duePage, setDuePage] = useState(1);
-  const [hotPage, setHotPage] = useState(1);
   const pageSize = 5;
 
-  const duePaged = dueProjects.slice(
-    (duePage - 1) * pageSize,
-    duePage * pageSize
-  );
-  const hotPaged = hotProjects.slice(
-    (hotPage - 1) * pageSize,
-    hotPage * pageSize
-  );
+  useEffect(() => {
+    dispatch(fetchDashboardSummary());
+  }, [dispatch]);
+
+  useEffect(() => {
+    dispatch(fetchNearDeadlineProjects({ page: duePage }));
+  }, [dispatch, duePage]);
 
   return (
     <PageWrapper>
@@ -104,39 +51,19 @@ export default function DashboardPage() {
       />
 
       <Box display="flex" justifyContent="space-between" mb={4}>
-        <InfoCard label="전체 프로젝트" value={totalCount} />
-        <InfoCard label="진행중" value={inProgressCount} />
-        <InfoCard label="만료됨" value={expiredCount} />
+        <InfoCard label="전체 프로젝트" value={safeSummary.totalCount} />
+        <InfoCard label="진행중" value={safeSummary.inProgressCount} />
+        <InfoCard label="완료됨" value={safeSummary.completedCount} />
       </Box>
 
       <SectionBox title="마감임박 프로젝트 (5일 이내)">
-        {duePaged.map((p) => (
-          <RowItem
-            key={p.id}
-            title={p.name}
-            sub={`마감일: ${dayjs(p.endAt).format("YYYY-MM-DD")}`}
-          />
+        {nearDeadline.map((p) => (
+          <RowItem key={p.id} title={p.name} endAt={p.endAt} dday={p.dday} />
         ))}
         <Pagination
-          count={Math.ceil(dueProjects.length / pageSize)}
+          count={Math.ceil(nearDeadlineTotalCount / pageSize)}
           page={duePage}
           onChange={(_, val) => setDuePage(val)}
-          sx={{ mt: 2 }}
-        />
-      </SectionBox>
-
-      <SectionBox title="게시글 많은 프로젝트">
-        {hotPaged.map((p) => (
-          <RowItem
-            key={p.id}
-            title={p.name}
-            sub={`게시글 수: ${p.postCount}`}
-          />
-        ))}
-        <Pagination
-          count={Math.ceil(hotProjects.length / pageSize)}
-          page={hotPage}
-          onChange={(_, val) => setHotPage(val)}
           sx={{ mt: 2 }}
         />
       </SectionBox>
@@ -144,7 +71,6 @@ export default function DashboardPage() {
   );
 }
 
-// ✅ 정보 카운터 카드 (flat 스타일)
 function InfoCard({ label, value }) {
   return (
     <Box
@@ -165,7 +91,6 @@ function InfoCard({ label, value }) {
   );
 }
 
-// ✅ Section 구분 박스
 function SectionBox({ title, children }) {
   return (
     <Box
@@ -185,15 +110,26 @@ function SectionBox({ title, children }) {
   );
 }
 
-// ✅ 개별 리스트 아이템
-function RowItem({ title, sub }) {
+function RowItem({ title, endAt, dday }) {
   return (
     <Box>
-      <Stack direction="row" justifyContent="space-between" mb={1}>
-        <Typography>{title}</Typography>
-        <Typography variant="body2" color="text.secondary">
-          {sub}
-        </Typography>
+      <Stack
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        mb={1}
+      >
+        <Box>
+          <Typography fontWeight={500}>{title}</Typography>
+          <Typography variant="body2" color="text.secondary">
+            마감일: {dayjs(endAt).format("YYYY-MM-DD")}
+          </Typography>
+        </Box>
+        <Chip
+          label={`D-${dday}`}
+          color={dday <= 1 ? "error" : dday <= 3 ? "warning" : "default"}
+          variant="outlined"
+        />
       </Stack>
       <Divider sx={{ mb: 1 }} />
     </Box>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -8,20 +8,20 @@ import projectStepReducer from "@/features/project/projectStepSlice";
 import postReducer from "@/features/project/post/postSlice";
 import projectMemberReducer from "@/features/project/projectMemberSlice";
 import reviewReducer from "@/features/project/post/reviewSlice";
-
+import DashboardReducer from "@/features/dashboard/DashboardSlice";
 
 const preloadedAuth = (() => {
   try {
-    const token       = localStorage.getItem("accessToken");
-    const userJson    = localStorage.getItem("user");
+    const token = localStorage.getItem("accessToken");
+    const userJson = localStorage.getItem("user");
     const companyJson = localStorage.getItem("company");
     if (token && userJson && companyJson) {
       return {
         accessToken: token,
-        user:        JSON.parse(userJson),
-        company:     JSON.parse(companyJson),
-        status:      "succeeded",
-        error:       null,
+        user: JSON.parse(userJson),
+        company: JSON.parse(companyJson),
+        status: "succeeded",
+        error: null,
       };
     }
   } catch {
@@ -29,23 +29,24 @@ const preloadedAuth = (() => {
   }
   return {
     accessToken: null,
-    user:        null,
-    company:     null,
-    status:      "idle",
-    error:       null,
+    user: null,
+    company: null,
+    status: "idle",
+    error: null,
   };
 })();
 
 export const store = configureStore({
   reducer: {
-    project:        projectReducer,
-    member:         memberReducer,
-    company:        companyReducer,
-    auth:           authReducer,
-    projectStep:    projectStepReducer,
-    post:           postReducer,
-    projectMember:  projectMemberReducer,
-    review: reviewReducer
+    project: projectReducer,
+    member: memberReducer,
+    company: companyReducer,
+    auth: authReducer,
+    projectStep: projectStepReducer,
+    post: postReducer,
+    projectMember: projectMemberReducer,
+    review: reviewReducer,
+    dashboard: DashboardReducer,
   },
   preloadedState: {
     auth: preloadedAuth,


### PR DESCRIPTION
## 📌 개요

* 대시보드 페이지에 백엔드 API를 연동하여 실제 데이터를 기반으로 프로젝트 요약 및 마감 임박 프로젝트 정보를 표시하도록 구현했습니다.

---

## 🛠️ 변경 사항

* `api/dashboard.js`에 요약 정보 및 마감 프로젝트 API 함수 추가
* `dashboardSlice.js` 생성하여 Redux 상태 관리 로직 구성
* `DashboardPage.jsx`에 대시보드 API 연동 및 시각화 구현

  * 요약 정보: 전체, 진행중, 완료
  * 마감 임박 프로젝트(D-5 이하) 목록 및 D-day 뱃지 스타일 추가

---

## ✅ 주요 체크 포인트

* [ ] 요약 정보(`totalCount`, `inProgressCount`, `completedCount`)가 정상적으로 출력되는지 확인
* [ ] 마감 임박 프로젝트가 D-day 기준으로 정렬되어 출력되는지 확인
* [ ] 페이지네이션 동작이 정상적으로 수행되는지 확인

---

## 🔁 테스트 결과

* 로컬 서버에서 마감 임박 프로젝트 및 요약 정보 정상 출력 확인
* 페이지 이동 시 해당 페이지 데이터 정상 호출 확인됨

---

## 🔗 연관된 이슈

* #223 

---

## 📑 레퍼런스

* 없음
