### PR TITLE
[feat] 로그인 성공 시 대시보드로 이동하도록 리디렉션 경로 수정(#225)

### DIFF
--- a/src/features/auth/pages/LoginPage.jsx
+++ b/src/features/auth/pages/LoginPage.jsx
@@ -41,7 +41,7 @@ export default function LoginPage() {
 
   useEffect(() => {
     if (accessToken) {
-      navigate("/projects", { replace: true });
+      navigate("/dashboard", { replace: true });
     }
   }, [accessToken, navigate]);
 
@@ -51,35 +51,7 @@ export default function LoginPage() {
 
     const result = await dispatch(login(form));
     if (login.fulfilled.match(result)) {
-      const { memberRole, memberId } = result.payload;
-
-      if (memberRole === "ROLE_USER") {
-        try {
-          const memberProjectResult = await dispatch(
-            fetchMemberProjects(memberId)
-          );
-
-          if (fetchMemberProjects.fulfilled.match(memberProjectResult)) {
-            const projects = memberProjectResult.payload.memberProjects || [];
-
-            if (projects.length > 0) {
-              navigate(`/projects/${projects[0].id}`);
-            } else {
-              navigate("/no-projects");
-            }
-          } else {
-            navigate("/no-projects");
-          }
-        } catch (err) {
-          navigate("/no-projects", {
-            state: { warningMessage: "프로젝트 조회 중 오류가 발생했습니다." },
-          });
-        }
-        return;
-      }
-
-      // ROLE_USER 외에는 그냥 /projects로 이동
-      navigate("/projects");
+      navigate("/dashboard");
     } else {
       console.error("로그인 실패:", result.payload || result.error);
     }

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -112,7 +112,7 @@ export default function MainRoutes() {
         path="/"
         element={
           isAuthenticated ? (
-            <Navigate to="/projects" replace />
+            <Navigate to="/dashboard" replace />
           ) : (
             <Navigate to="/login" replace />
           )


### PR DESCRIPTION
## 📌 개요

* 로그인 성공 시 권한과 무관하게 대시보드(`/dashboard`)로 이동하도록 리디렉션 경로를 수정했습니다.

---

## 🛠️ 변경 사항

* 기존에 `ROLE_USER`일 경우만 별도 프로젝트 조회 후 리디렉션하던 로직 제거
* 로그인 성공 시 `/dashboard`로 일괄 이동하도록 처리
* `fetchMemberProjects` 호출 및 관련 분기 로직 삭제
* `/projects`, `/no-projects` 관련 이동 경로 제거

---

## ✅ 주요 체크 포인트

* [ ] 로그인 후 대시보드로 정상적으로 이동하는지 확인해주세요.
* [ ] 이전에 존재하던 프로젝트 리스트 리디렉션 로직이 완전히 제거되었는지 확인 부탁드립니다.

---

## 🔁 테스트 결과

* 로컬에서 로그인 시 `/dashboard`로 정상 이동되는지 직접 테스트 완료
* 로그인 실패 시에는 에러 메시지 정상 출력됨 확인

---

## 🔗 연관된 이슈

* #225 

---

## 📑 레퍼런스

* 없음
