### PR TITLE
[fix]대시보드 페이지에서 누락된 dashboardSlice import 경로 수정(#223)

### DIFF
--- a/src/features/dashboard/pages/DashboardPage.jsx
+++ b/src/features/dashboard/pages/DashboardPage.jsx
@@ -14,7 +14,7 @@ import { useDispatch, useSelector } from "react-redux";
 import {
   fetchDashboardSummary,
   fetchNearDeadlineProjects,
-} from "@/features/dashboard/dashboardSlice";
+} from "../DashboardSlice";
 
 export default function DashboardPage() {
   const dispatch = useDispatch();


### PR DESCRIPTION
## 📌 개요

* 대시보드 페이지에서 누락되었거나 잘못된 `dashboardSlice` import 경로로 인해 발생한 Vite 빌드 오류 수정

## 🛠️ 변경 사항

* `DashboardPage.jsx`에서 `dashboardSlice` import 경로 수정
* 누락된 `dashboardSlice` 파일이 존재하지 않는 경우 새로 생성 또는 기존 위치로 이동

## ✅ 주요 체크 포인트

* [ ] import 경로가 실제 파일 경로와 일치하는지 확인
* [ ] Vite 빌드 및 실행 시 오류가 발생하지 않는지 확인

## 🔁 테스트 결과

* 로컬 환경에서 `yarn dev`로 실행 시 정상적으로 빌드 및 페이지 렌더링 확인
* 대시보드 페이지 진입 시 정상 동작 확인

## 🔗 연관된 이슈

* `- #223`

## 📑 레퍼런스

* 없음