### PR TITLE
[feat] 활동 로그 페이지 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# Logs
-logs
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/src/components/common/customTable/CustomTable.jsx
+++ b/src/components/common/customTable/CustomTable.jsx
@@ -37,8 +37,10 @@ export default function CustomTable({
   onRowClick,
   search = null,
   filter = null,
+  secondaryFilter = null,
   onEdit, // (row) => void
   onDelete, // (row) => void
+  hideDeleteButton = false, // 삭제 버튼 숨김 옵션 추가
 }) {
   const { companyListOnlyIdName: companies = [] } = useSelector(
     (state) => state.company
@@ -85,8 +87,18 @@ export default function CustomTable({
         );
       }
     }
+    if (secondaryFilter && secondaryFilter.key) {
+      const { key, value } = secondaryFilter;
+      if (value !== "") {
+        result = result.filter(
+          (row) =>
+            row[key] ===
+            (value === "true" ? true : value === "false" ? false : value)
+        );
+      }
+    }
     return result;
-  }, [rows, searchKey, searchText, search, filter]);
+  }, [rows, searchKey, searchText, search, filter, secondaryFilter]);
 
   // 정렬 적용
   const sortedRows = useMemo(() => {
@@ -152,6 +164,29 @@ export default function CustomTable({
                   }
                 >
                   {filter.options.map((opt) => (
+                    <MenuItem key={String(opt.value)} value={opt.value}>
+                      {opt.label}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+
+            {secondaryFilter && secondaryFilter.key && (
+              <FormControl size="small" sx={{ minWidth: 120 }}>
+                <InputLabel>
+                  {secondaryFilter.label ??
+                    columns.find((c) => c.key === secondaryFilter.key)?.label}
+                </InputLabel>
+                <Select
+                  value={secondaryFilter.value}
+                  onChange={(e) => secondaryFilter.onChange?.(e.target.value)}
+                  label={
+                    secondaryFilter.label ??
+                    columns.find((c) => c.key === secondaryFilter.key)?.label
+                  }
+                >
+                  {secondaryFilter.options.map((opt) => (
                     <MenuItem key={String(opt.value)} value={opt.value}>
                       {opt.label}
                     </MenuItem>
@@ -244,8 +279,8 @@ export default function CustomTable({
                     </TableCell>
                   ))}
                   {/* 액션 컬럼 */}
-                  <TableCell key="__actions__" align="center">
-                    {userRole === "ROLE_SYSTEM_ADMIN" && (
+                  {userRole === "ROLE_SYSTEM_ADMIN" && !hideDeleteButton && (
+                    <TableCell key="__actions__" align="center">
                       <CustomButton
                         kind="ghost-danger"
                         size="small"
@@ -256,8 +291,8 @@ export default function CustomTable({
                       >
                         삭제
                       </CustomButton>
-                    )}
-                  </TableCell>
+                    </TableCell>
+                  )}
                 </TableRow>
               ))}
             </TableBody>

--- a/src/constants/navItems.js
+++ b/src/constants/navItems.js
@@ -4,6 +4,7 @@ import BusinessRoundedIcon from "@mui/icons-material/BusinessRounded";
 import PersonIcon from "@mui/icons-material/Person";
 import AddBoxRoundedIcon from "@mui/icons-material/AddBoxRounded";
 import ListRoundedIcon from "@mui/icons-material/ListRounded";
+import HistoryIcon from "@mui/icons-material/History";
 import { ROLES } from "@/constants/roles";
 
 const navItems = [
@@ -86,6 +87,12 @@ const navItems = [
     icon: PersonIcon,
     path: "/members",
     roles: [ROLES.DEV_ADMIN, ROLES.CLIENT_ADMIN],
+  },
+  {
+    text: "로그 기록",
+    icon: HistoryIcon,
+    path: "/logs",
+    roles: [ROLES.SYSTEM_ADMIN, ROLES.DEV_ADMIN],
   },
 ];
 

--- a/src/features/logs/LogsPage.jsx
+++ b/src/features/logs/LogsPage.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import PageWrapper from '../../components/layouts/pageWrapper/PageWrapper';
+import PageHeader from '../../components/layouts/pageHeader/PageHeader';
+import LogsTable from './components/LogsTable';
+
+const LogsPage = () => {
+  return (
+    <PageWrapper>
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          height: "100%",
+          borderRadius: 2,
+        }}
+      >
+        <PageHeader
+          title="로그 기록"
+          subtitle="시스템의 모든 활동 로그를 확인할 수 있습니다."
+        />
+        <Box sx={{ flex: 1, overflow: "hidden", mb: 0.3 }}>
+          <LogsTable />
+        </Box>
+      </Box>
+    </PageWrapper>
+  );
+};
+
+export default LogsPage; 

--- a/src/features/logs/api/logsApi.js
+++ b/src/features/logs/api/logsApi.js
@@ -1,0 +1,31 @@
+import api from '../../../api/api';
+
+export const getLogs = async (page = 0, size = 10) => {
+  try {
+    const response = await api.get(`/logs?page=${page}&size=${size}`);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching logs:', error);
+    throw error;
+  }
+};
+
+export const getActivityLogs = async (page = 1, actionType = '', targetType = '') => {
+  try {
+    let url = `/api/activity-logs?page=${page}`;
+    
+    if (actionType) {
+      url += `&actionType=${actionType}`;
+    }
+    
+    if (targetType) {
+      url += `&targetType=${targetType}`;
+    }
+    
+    const response = await api.get(url);
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching activity logs:', error);
+    throw error;
+  }
+}; 

--- a/src/features/logs/components/LogsTable.jsx
+++ b/src/features/logs/components/LogsTable.jsx
@@ -1,24 +1,87 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { 
+  Box, 
+  Alert, 
+  CircularProgress, 
+  Dialog, 
+  DialogTitle, 
+  DialogContent, 
+  DialogActions, 
+  Button, 
+  Typography, 
+  Divider,
+  Chip
+} from '@mui/material';
 import CustomTable from '@/components/common/customTable/CustomTable';
-import { Box } from '@mui/material';
+import { 
+  fetchActivityLogs, 
+  setCurrentPage, 
+  clearLogsError,
+  setActionTypeFilter,
+  setTargetTypeFilter
+} from '../logsSlice';
 
 const LogsTable = () => {
-  const [page, setPage] = useState(1);
-  const [actionFilterValue, setActionFilterValue] = useState('');
-  const [targetTypeFilterValue, setTargetTypeFilterValue] = useState('');
+  const dispatch = useDispatch();
+  const { 
+    activityLogs, 
+    totalCount, 
+    currentPage, 
+    actionTypeFilter,
+    targetTypeFilter,
+    loading, 
+    error 
+  } = useSelector((state) => state.logs);
+
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [selectedLogDetails, setSelectedLogDetails] = useState([]);
+
+  // 컴포넌트 마운트 시 데이터 로드
+  useEffect(() => {
+    dispatch(fetchActivityLogs({ 
+      page: currentPage, 
+      actionType: actionTypeFilter, 
+      targetType: targetTypeFilter 
+    }));
+  }, [dispatch, currentPage, actionTypeFilter, targetTypeFilter]);
+
+  // 에러 발생 시 5초 후 자동으로 에러 메시지 제거
+  useEffect(() => {
+    if (error) {
+      const timer = setTimeout(() => {
+        dispatch(clearLogsError());
+      }, 5000);
+      return () => clearTimeout(timer);
+    }
+  }, [error, dispatch]);
+
+  // 상세보기 팝업 열기
+  const handleShowDetails = (logDetails) => {
+    // UNKNOWN_FIELD_TYPE 제외
+    const filteredDetails = logDetails.filter(detail => detail.fieldType !== 'UNKNOWN_FIELD_TYPE');
+    setSelectedLogDetails(filteredDetails);
+    setDetailsOpen(true);
+  };
+
+  // 상세보기 팝업 닫기
+  const handleCloseDetails = () => {
+    setDetailsOpen(false);
+    setSelectedLogDetails([]);
+  };
 
   // 테이블 컬럼 정의
   const columns = [
-    { key: 'timestamp', label: '시간', type: 'text' },
-    { key: 'actor', label: '액션자 이름', type: 'text' },
+    { key: 'actionTime', label: '시간', type: 'text' },
+    { key: 'actorName', label: '액션자 이름', type: 'text' },
     {
-      key: 'action',
+      key: 'actionType',
       label: '액션',
       type: 'status',
       statusMap: {
-        create: { color: 'success', label: '생성' },
-        modify: { color: 'warning', label: '수정' },
-        delete: { color: 'error', label: '삭제' },
+        CREATE: { color: 'success', label: '생성' },
+        MODIFY: { color: 'warning', label: '수정' },
+        DELETE: { color: 'error', label: '삭제' },
       },
     },
     {
@@ -26,68 +89,255 @@ const LogsTable = () => {
       label: '액션대상타입',
       type: 'text',
     },
-    { key: 'content', label: '컨텐츠 요약', type: 'text' },
-  ];
-
-  // 임시 데이터 (실제로는 API에서 가져와야 함)
-  const logs = [
-    {
-      id: 1,
-      timestamp: '2024-03-20 14:30:00',
-      actor: '홍길동',
-      action: 'create',
-      targetType: '게시글',
-      content: '새로운 프로젝트 계획서 작성',
+    { key: 'actorCompanyName', label: '회사명', type: 'text' },
+    { 
+      key: 'logDetails', 
+      label: '변경 내용', 
+      type: 'custom',
+      render: (value, row) => {
+        if (!value || value.length === 0) {
+          return <span style={{ color: '#999' }}>-</span>;
+        }
+        return (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              handleShowDetails(row.logDetails);
+            }}
+            style={{
+              background: '#1a1a1a',
+              color: 'white',
+              border: 'none',
+              borderRadius: '6px',
+              padding: '6px 12px',
+              fontSize: '12px',
+              cursor: 'pointer',
+              fontWeight: '500',
+              transition: 'all 0.2s ease',
+              boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+              ':hover': {
+                background: '#3d3d3d',
+                transform: 'translateY(-1px)',
+                boxShadow: '0 2px 6px rgba(0,0,0,0.15)'
+              }
+            }}
+            onMouseEnter={(e) => {
+              e.target.style.background = '#3d3d3d';
+              e.target.style.transform = 'translateY(-1px)';
+              e.target.style.boxShadow = '0 2px 6px rgba(0,0,0,0.15)';
+            }}
+            onMouseLeave={(e) => {
+              e.target.style.background = '#1a1a1a';
+              e.target.style.transform = 'translateY(0)';
+              e.target.style.boxShadow = '0 1px 3px rgba(0,0,0,0.1)';
+            }}
+          >
+            상세보기
+          </button>
+        );
+      }
     },
-    // ... 더 많은 로그 데이터
   ];
 
   // 액션 필터 옵션
   const actionFilterOptions = [
     { label: '전체', value: '' },
-    { label: '생성', value: 'create' },
-    { label: '수정', value: 'modify' },
-    { label: '삭제', value: 'delete' },
+    { label: '생성', value: 'CREATE' },
+    { label: '수정', value: 'MODIFY' },
+    { label: '삭제', value: 'DELETE' },
   ];
 
-  // 액션 대상타입 필터 옵션
+  // 액션 대상타입 필터 옵션 (8개로 확장)
   const targetTypeFilterOptions = [
     { label: '전체', value: '' },
-    { label: '게시글', value: '게시글' },
-    { label: '프로젝트', value: '프로젝트' },
-    { label: '회원', value: '회원' },
-    { label: '회사', value: '회사' },
+    { label: '게시글', value: 'POST' },
+    { label: '리뷰', value: 'REVIEW' },
+    { label: '프로젝트 체크리스트', value: 'PROJECT_CHECK_LIST' },
+    { label: '회원', value: 'MEMBER' },
+    { label: '회사', value: 'COMPANY' },
+    { label: '프로젝트', value: 'PROJECT' },
+    { label: '프로젝트 단계', value: 'PROJECT_STEP' },
+    { label: '프로젝트 멤버', value: 'PROJECT_MEMBER' },
   ];
 
-  // 필터링된 데이터
-  const filteredLogs = logs.filter(log => {
-    const actionMatch = !actionFilterValue || log.action === actionFilterValue;
-    const targetTypeMatch = !targetTypeFilterValue || log.targetType === targetTypeFilterValue;
-    return actionMatch && targetTypeMatch;
-  });
+  // 페이지 변경 핸들러
+  const handlePageChange = (newPage) => {
+    dispatch(setCurrentPage(newPage)); // 이제 모두 1-based
+  };
+
+  // 필터 변경 핸들러
+  const handleActionFilterChange = (value) => {
+    dispatch(setActionTypeFilter(value));
+  };
+
+  const handleTargetTypeFilterChange = (value) => {
+    dispatch(setTargetTypeFilter(value));
+  };
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" alignItems="center" height="200px">
+        <CircularProgress />
+      </Box>
+    );
+  }
 
   return (
     <Box>
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+      
       <CustomTable
         columns={columns}
-        rows={filteredLogs}
+        rows={activityLogs}
         pagination={{
-          page,
-          total: filteredLogs.length,
-          onPageChange: (newPage) => setPage(newPage),
+          page: currentPage,
+          total: totalCount,
+          onPageChange: handlePageChange,
           pageSize: 10,
         }}
         filter={{
-          key: 'action',
+          key: 'actionType',
           label: '액션',
-          value: actionFilterValue,
+          value: actionTypeFilter,
           options: actionFilterOptions,
-          onChange: (value) => {
-            setActionFilterValue(value);
-            setPage(1);
-          },
+          onChange: handleActionFilterChange,
         }}
+        secondaryFilter={{
+          key: 'targetType',
+          label: '대상 타입',
+          value: targetTypeFilter,
+          options: targetTypeFilterOptions,
+          onChange: handleTargetTypeFilterChange,
+        }}
+        hideDeleteButton={true}
       />
+
+      <Dialog 
+        open={detailsOpen} 
+        onClose={handleCloseDetails}
+        maxWidth="md"
+        fullWidth
+      >
+        <DialogTitle sx={{ pb: 1 }}>
+          <Typography variant="h6" fontWeight="bold">
+            변경 내용 상세보기
+          </Typography>
+        </DialogTitle>
+        <DialogContent sx={{ pt: 2 }}>
+          {selectedLogDetails.length === 0 ? (
+            <Typography variant="body1" color="text.secondary" textAlign="center" py={3}>
+              변경된 내용이 없습니다.
+            </Typography>
+          ) : (
+            <Box>
+              {selectedLogDetails.map((detail, index) => {
+                // fieldType을 한글로 변환
+                const getFieldTypeLabel = (fieldType) => {
+                  const fieldTypeMap = {
+                    'PROJECT_NAME': '프로젝트명',
+                    'PROJECT_DETAIL': '프로젝트 상세',
+                    'PROJECT_START_AT': '시작일',
+                    'PROJECT_END_AT': '종료일',
+                    'PROJECT_STATUS': '프로젝트 상태',
+                    'MEMBER_NAME': '회원명',
+                    'MEMBER_EMAIL': '이메일',
+                    'MEMBER_ROLE': '권한',
+                    'COMPANY_NAME': '회사명',
+                    'COMPANY_TYPE': '회사 유형',
+                    'POST_TITLE': '게시글 제목',
+                    'POST_CONTENT': '게시글 내용',
+                    'REVIEW_COMMENT': '리뷰 내용',
+                    'STEP_NAME': '단계명',
+                    'STEP_STATUS': '단계 상태',
+                    'CHECKLIST_ITEM': '체크리스트 항목',
+                    'CHECKLIST_STATUS': '체크리스트 상태'
+                  };
+                  return fieldTypeMap[fieldType] || fieldType;
+                };
+
+                const fieldLabel = getFieldTypeLabel(detail.fieldType);
+                const oldValue = detail.oldValue || '-';
+                const newValue = detail.newValue || '-';
+
+                return (
+                  <Box key={index} sx={{ mb: 3 }}>
+                    <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+                      <Chip 
+                        label={fieldLabel} 
+                        size="small" 
+                        color="primary" 
+                        variant="outlined"
+                        sx={{ mr: 1 }}
+                      />
+                    </Box>
+                    
+                    <Box sx={{ 
+                      display: 'flex', 
+                      alignItems: 'center', 
+                      gap: 2,
+                      p: 2,
+                      bgcolor: 'grey.50',
+                      borderRadius: 1,
+                      border: '1px solid',
+                      borderColor: 'grey.200'
+                    }}>
+                      <Box sx={{ flex: 1 }}>
+                        <Typography variant="caption" color="text.secondary" display="block">
+                          이전 값
+                        </Typography>
+                        <Typography variant="body2" sx={{ 
+                          wordBreak: 'break-word',
+                          color: oldValue === '-' ? 'text.disabled' : 'text.primary'
+                        }}>
+                          {oldValue}
+                        </Typography>
+                      </Box>
+                      
+                      <Box sx={{ 
+                        display: 'flex', 
+                        alignItems: 'center', 
+                        color: 'primary.main',
+                        fontWeight: 'bold'
+                      }}>
+                        →
+                      </Box>
+                      
+                      <Box sx={{ flex: 1 }}>
+                        <Typography variant="caption" color="text.secondary" display="block">
+                          변경된 값
+                        </Typography>
+                        <Typography variant="body2" sx={{ 
+                          wordBreak: 'break-word',
+                          color: newValue === '-' ? 'text.disabled' : 'text.primary'
+                        }}>
+                          {newValue}
+                        </Typography>
+                      </Box>
+                    </Box>
+                    
+                    {index < selectedLogDetails.length - 1 && (
+                      <Divider sx={{ mt: 2 }} />
+                    )}
+                  </Box>
+                );
+              })}
+            </Box>
+          )}
+        </DialogContent>
+        <DialogActions sx={{ p: 2, pt: 1 }}>
+          <Button 
+            onClick={handleCloseDetails}
+            variant="contained"
+            size="small"
+          >
+            닫기
+          </Button>
+        </DialogActions>
+      </Dialog>
     </Box>
   );
 };

--- a/src/features/logs/components/LogsTable.jsx
+++ b/src/features/logs/components/LogsTable.jsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import CustomTable from '@/components/common/customTable/CustomTable';
+import { Box } from '@mui/material';
+
+const LogsTable = () => {
+  const [page, setPage] = useState(1);
+  const [actionFilterValue, setActionFilterValue] = useState('');
+  const [targetTypeFilterValue, setTargetTypeFilterValue] = useState('');
+
+  // 테이블 컬럼 정의
+  const columns = [
+    { key: 'timestamp', label: '시간', type: 'text' },
+    { key: 'actor', label: '액션자 이름', type: 'text' },
+    {
+      key: 'action',
+      label: '액션',
+      type: 'status',
+      statusMap: {
+        create: { color: 'success', label: '생성' },
+        modify: { color: 'warning', label: '수정' },
+        delete: { color: 'error', label: '삭제' },
+      },
+    },
+    {
+      key: 'targetType',
+      label: '액션대상타입',
+      type: 'text',
+    },
+    { key: 'content', label: '컨텐츠 요약', type: 'text' },
+  ];
+
+  // 임시 데이터 (실제로는 API에서 가져와야 함)
+  const logs = [
+    {
+      id: 1,
+      timestamp: '2024-03-20 14:30:00',
+      actor: '홍길동',
+      action: 'create',
+      targetType: '게시글',
+      content: '새로운 프로젝트 계획서 작성',
+    },
+    // ... 더 많은 로그 데이터
+  ];
+
+  // 액션 필터 옵션
+  const actionFilterOptions = [
+    { label: '전체', value: '' },
+    { label: '생성', value: 'create' },
+    { label: '수정', value: 'modify' },
+    { label: '삭제', value: 'delete' },
+  ];
+
+  // 액션 대상타입 필터 옵션
+  const targetTypeFilterOptions = [
+    { label: '전체', value: '' },
+    { label: '게시글', value: '게시글' },
+    { label: '프로젝트', value: '프로젝트' },
+    { label: '회원', value: '회원' },
+    { label: '회사', value: '회사' },
+  ];
+
+  // 필터링된 데이터
+  const filteredLogs = logs.filter(log => {
+    const actionMatch = !actionFilterValue || log.action === actionFilterValue;
+    const targetTypeMatch = !targetTypeFilterValue || log.targetType === targetTypeFilterValue;
+    return actionMatch && targetTypeMatch;
+  });
+
+  return (
+    <Box>
+      <CustomTable
+        columns={columns}
+        rows={filteredLogs}
+        pagination={{
+          page,
+          total: filteredLogs.length,
+          onPageChange: (newPage) => setPage(newPage),
+          pageSize: 10,
+        }}
+        filter={{
+          key: 'action',
+          label: '액션',
+          value: actionFilterValue,
+          options: actionFilterOptions,
+          onChange: (value) => {
+            setActionFilterValue(value);
+            setPage(1);
+          },
+        }}
+      />
+    </Box>
+  );
+};
+
+export default LogsTable; 

--- a/src/features/logs/logsSlice.js
+++ b/src/features/logs/logsSlice.js
@@ -1,0 +1,69 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import * as logsAPI from './api/logsApi';
+
+// ActivityLog 목록 조회 (필터 파라미터 추가)
+export const fetchActivityLogs = createAsyncThunk(
+  'logs/fetchActivityLogs',
+  async ({ page = 1, actionType = '', targetType = '' }, thunkAPI) => {
+    try {
+      const response = await logsAPI.getActivityLogs(page, actionType, targetType);
+      return response.data;
+    } catch (error) {
+      return thunkAPI.rejectWithValue(error.response?.data || 'Activity logs 조회 실패');
+    }
+  }
+);
+
+const logsSlice = createSlice({
+  name: 'logs',
+  initialState: {
+    activityLogs: [],
+    totalCount: 0,
+    currentPage: 1, // 1-based로 변경
+    actionTypeFilter: '', // 액션 타입 필터 상태
+    targetTypeFilter: '', // 대상 타입 필터 상태
+    loading: false,
+    error: null,
+  },
+  reducers: {
+    clearLogsError: (state) => {
+      state.error = null;
+    },
+    setCurrentPage: (state, action) => {
+      state.currentPage = action.payload;
+    },
+    setActionTypeFilter: (state, action) => {
+      state.actionTypeFilter = action.payload;
+      state.currentPage = 1; // 필터 변경시 첫 페이지로
+    },
+    setTargetTypeFilter: (state, action) => {
+      state.targetTypeFilter = action.payload;
+      state.currentPage = 1; // 필터 변경시 첫 페이지로
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      // fetchActivityLogs
+      .addCase(fetchActivityLogs.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchActivityLogs.fulfilled, (state, action) => {
+        state.loading = false;
+        state.activityLogs = action.payload.activityLogSelectWebResponses || [];
+        state.totalCount = action.payload.totalCount || 0;
+      })
+      .addCase(fetchActivityLogs.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      });
+  },
+});
+
+export const { 
+  clearLogsError, 
+  setCurrentPage, 
+  setActionTypeFilter, 
+  setTargetTypeFilter 
+} = logsSlice.actions;
+export default logsSlice.reducer; 

--- a/src/routes/MainRoutes.jsx
+++ b/src/routes/MainRoutes.jsx
@@ -16,6 +16,7 @@ import DashboardPage from "@/features/dashboard/pages/DashboardPage";
 import CompanyPage from "@/features/company/pages/CompanyPage";
 import CompanyFormPage from "@/features/company/pages/CompanyFormPage";
 import CompanyDetailPage from "@/features/company/pages/CompanyDetailPage";
+import LogsPage from "@/features/logs/LogsPage";
 import ProtectedRoute from "@/components/common/protectedRoute/ProtectedRoute";
 import ForbiddenPage from "@/components/common/errorPage/ForbiddenPage";
 import NotFoundPage from "@/components/common/errorPage/NotFoundPage";
@@ -108,6 +109,8 @@ export default function MainRoutes() {
         <Route path="/forbidden" element={<ForbiddenPage />} />
         <Route path="/not-found" element={<NotFoundPage />} />
         <Route path="*" element={<NotFoundPage />} />
+        
+        <Route path="/logs" element={<LogsPage />} />
       </Route>
       <Route path="/login" element={<LoginPage />} />
       <Route

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -9,6 +9,7 @@ import postReducer from "@/features/project/post/postSlice";
 import projectMemberReducer from "@/features/project/slices/projectMemberSlice";
 import reviewReducer from "@/features/project/post/reviewSlice";
 import DashboardReducer from "@/features/dashboard/DashboardSlice";
+import logsReducer from "@/features/logs/logsSlice";
 
 const preloadedAuth = (() => {
   try {
@@ -47,6 +48,7 @@ export const store = configureStore({
     projectMember: projectMemberReducer,
     review: reviewReducer,
     dashboard: DashboardReducer,
+    logs: logsReducer,
   },
   preloadedState: {
     auth: preloadedAuth,


### PR DESCRIPTION
## 📌 개요
- ActivityLog 페이지에 백엔드 API를 연동하였습니다.
- 상세보기 기능과 필터링 옵션을 확장했습니다.

## 🛠️ 변경 사항

- ActivityLog API 연동 (GET /api/activity-logs) 구현
- Redux 상태 관리 추가 (actionTypeFilter, targetTypeFilter)
- 페이징 처리

## ✅ 주요 체크 포인트
- [ ] 서버 사이드 필터링 로직이 올바르게 구현되었는지 확인
- [ ] API 호출 시 쿼리 파라미터가 정확히 전달되는지 확인
- [ ] 필터 변경 시 페이지가 1로 리셋되는지 확인
- [ ] 상세보기 팝업에서 UNKNOWN_FIELD_TYPE이 제외되는지 확인
- [ ] CustomTable의 secondaryFilter 기능이 다른 페이지에 영향을 주지 않는지 확인
- [ ] 공통 컴포넌트 개선
    - CustomTable에 secondaryFilter 기능 추가
    - hideDeleteButton prop 추가로 삭제 버튼 선택적 숨김 기능

## 🔁 테스트 결과
### API 연동 테스트
✅ 백엔드 서버 실행 시 정상적으로 데이터 로드
✅ 백엔드 서버 중단 시 적절한 에러 메시지 표시
✅ 필터 변경 시 새로운 API 호출 확인
### 필터링 테스트
✅ 액션 타입 필터 (CREATE, MODIFY, DELETE) 정상 작동
✅ 대상 타입 필터 8개 모두 정상 작동
✅ 필터 조합 시 정상 작동
✅ 페이지 변경 시 필터 조건 유지
### UI 테스트
✅ 상세보기 버튼 클릭 시 팝업 정상 표시
✅ 상세보기 팝업에서 변경사항 명확히 표시
✅ 삭제 버튼 완전히 숨김
✅ 반응형 디자인 정상 작동

## 🔗 연관된 이슈
- #237 