### PR TITLE
feat: 프로젝트 상태값 이름변경 및상세페이지에  결제금액 필드 노출#258

### DIFF
--- a/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
+++ b/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
@@ -22,6 +22,7 @@ export default function ProjectBasicInfoSectionContent({
   setPeriodStart,
   periodEnd,
   setPeriodEnd,
+  project,
 }) {
   return (
     <>
@@ -110,6 +111,18 @@ export default function ProjectBasicInfoSectionContent({
                   종료일
                 </Typography>
                 <Typography variant="body1">{periodEnd || "-"}</Typography>
+              </>
+            )}
+          </Grid>
+
+          <Grid item xs={12} sm={isEditable ? 12 : 6}>
+            {/* 읽기모드에서만 프로젝트 금액 노출 */}
+            {!isEditable && (
+              <>
+                <Typography variant="body2" color="text.secondary">
+                  프로젝트 금액(만원)
+                </Typography>
+                <Typography variant="body1">{project?.projectAmount ?? "-"}</Typography>
               </>
             )}
           </Grid>

--- a/src/features/project/home/pages/ProjectLayout.jsx
+++ b/src/features/project/home/pages/ProjectLayout.jsx
@@ -73,9 +73,9 @@ export default function ProjectLayout() {
   }
 
   const statusMap = {
-    NOT_STARTED: { color: "neutral", label: "계획" },
+    CONTRACT: { color: "neutral", label: "결제" },
     IN_PROGRESS: { color: "info", label: "진행" },
-    PAUSED: { color: "warning", label: "중단" },
+    PAYMENT: { color: "warning", label: "검수" },
     COMPLETED: { color: "success", label: "완료" },
   };
 


### PR DESCRIPTION
## 📌 개요
프로젝트 상태값 이름변경 및상세페이지에  결제금액 필드 노출#258

## 🛠️ 변경 사항

- 프로젝트 상태값 이름변경 
- 상세페이지에  결제금액 필드 노출( 결제, 진행중 , 검수 ,완료)

## ✅ 주요 체크 포인트

- [ ] 상태에 따른 이름 노출 확인.
- [ ] 상세 페이지에 프로젝트 금액확인.

## 🔁 테스트 결과
![image](https://github.com/user-attachments/assets/476929ff-e9c4-4aeb-8915-ac7ccc72b341)

## 🔗 연관된 이슈
#258 