### PR TITLE
feat: 알림 페이지 생성 #260

### DIFF
--- a/src/features/notifications/components/NotificationsDrawer.jsx
+++ b/src/features/notifications/components/NotificationsDrawer.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { Drawer, Box, Typography, IconButton, List, ListItem, ListItemText, Divider, Chip } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
+import dayjs from 'dayjs';
+import { formatNotificationDate } from '@/utils/dateUtils';
 
-// 임시 목업 데이터
+// 임시 목업 데이터 (LocalDateTime과 유사한 형식으로 수정)
 const mockNotifications = [
-  { id: 1, title: '새로운 리뷰가 등록되었습니다.', content: '프로젝트 A의 "로그인 기능"에 새로운 리뷰가 달렸습니다.', date: '3시간 전', read: false },
-  { id: 2, title: '결재가 승인되었습니다.', content: '요청하신 "디자인 시안"이 승인되었습니다.', date: '1일 전', read: false },
-  { id: 3, title: '새로운 멤버가 초대되었습니다.', content: '김민준님이 "마케팅팀"에 합류했습니다.', date: '3일 전', read: true },
-  { id: 4, title: '서버 점검 안내', content: '오늘 오후 10시에 정기 서버 점검이 있습니다.', date: '2024-06-20', read: true },
+  { id: 1, title: '새로운 리뷰가 등록되었습니다.', content: '프로젝트 A의 "로그인 기능"에 새로운 리뷰가 달렸습니다.', date: dayjs().subtract(3, 'hour').format('YYYY-MM-DDTHH:mm:ss'), read: false },
+  { id: 2, title: '결재가 승인되었습니다.', content: '요청하신 "디자인 시안"이 승인되었습니다.', date: dayjs().subtract(1, 'day').format('YYYY-MM-DDTHH:mm:ss'), read: false },
+  { id: 3, title: '새로운 멤버가 초대되었습니다.', content: '김민준님이 "마케팅팀"에 합류했습니다.', date: dayjs().subtract(3, 'day').format('YYYY-MM-DDTHH:mm:ss'), read: true },
+  { id: 4, title: '서버 점검 안내', content: '오늘 오후 10시에 정기 서버 점검이 있습니다.', date: dayjs().subtract(10, 'day').format('YYYY-MM-DDTHH:mm:ss'), read: true },
 ];
 
 export default function NotificationsDrawer({ open, onClose }) {
@@ -45,7 +47,7 @@ export default function NotificationsDrawer({ open, onClose }) {
                       {notif.title}
                     </Typography>
                     <Typography variant="caption" color="text.secondary">
-                      {notif.date}
+                      {formatNotificationDate(notif.date)}
                     </Typography>
                   </Box>
                 }

--- a/src/features/notifications/components/NotificationsDrawer.jsx
+++ b/src/features/notifications/components/NotificationsDrawer.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { Drawer, Box, Typography, IconButton, List, ListItem, ListItemText, Divider, Chip } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+// 임시 목업 데이터
+const mockNotifications = [
+  { id: 1, title: '새로운 리뷰가 등록되었습니다.', content: '프로젝트 A의 "로그인 기능"에 새로운 리뷰가 달렸습니다.', date: '3시간 전', read: false },
+  { id: 2, title: '결재가 승인되었습니다.', content: '요청하신 "디자인 시안"이 승인되었습니다.', date: '1일 전', read: false },
+  { id: 3, title: '새로운 멤버가 초대되었습니다.', content: '김민준님이 "마케팅팀"에 합류했습니다.', date: '3일 전', read: true },
+  { id: 4, title: '서버 점검 안내', content: '오늘 오후 10시에 정기 서버 점검이 있습니다.', date: '2024-06-20', read: true },
+];
+
+export default function NotificationsDrawer({ open, onClose }) {
+  return (
+    <Drawer
+      anchor="right"
+      open={open}
+      onClose={onClose}
+      PaperProps={{ sx: { width: 360, bgcolor: 'background.paper' } }}
+    >
+      <Box sx={{ p: 2, display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: 1, borderColor: 'divider' }}>
+        <Typography variant="h6" component="div">
+          수신함
+        </Typography>
+        <IconButton onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
+
+      <List sx={{ p: 0 }}>
+        {mockNotifications.map((notif, index) => (
+          <React.Fragment key={notif.id}>
+            <ListItem alignItems="flex-start" sx={{ py: 1.5, px: 2 }}>
+              <ListItemText
+                primary={
+                  <Box sx={{ display: 'flex', alignItems: 'center', mb: 0.5 }}>
+                    <Box component="span" sx={{
+                      width: 8,
+                      height: 8,
+                      borderRadius: '50%',
+                      bgcolor: notif.read ? 'grey.400' : 'blue.500',
+                      mr: 1.5,
+                    }} />
+                    <Typography variant="subtitle2" component="span" sx={{ flexGrow: 1, fontWeight: 'bold' }}>
+                      {notif.title}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {notif.date}
+                    </Typography>
+                  </Box>
+                }
+                secondary={
+                  <Typography variant="body2" color="text.secondary" sx={{ pl: 2.5 }}>
+                    {notif.content}
+                  </Typography>
+                }
+              />
+            </ListItem>
+            {index < mockNotifications.length - 1 && <Divider component="li" />}
+          </React.Fragment>
+        ))}
+      </List>
+    </Drawer>
+  );
+} 

--- a/src/features/notifications/notificationSlice.js
+++ b/src/features/notifications/notificationSlice.js
@@ -1,0 +1,33 @@
+import { createSlice } from '@reduxjs/toolkit';
+import dayjs from 'dayjs';
+
+// 임시 목업 데이터
+const mockNotifications = [
+  { id: 1, title: '새로운 리뷰 등록', content: '프로젝트 A의 "로그인 기능"에 새로운 리뷰가 달렸습니다.', date: dayjs().subtract(3, 'hour').format('YYYY-MM-DDTHH:mm:ss'), read: false },
+  { id: 2, title: '결재 승인', content: '요청하신 "디자인 시안"이 승인되었습니다.', date: dayjs().subtract(1, 'day').format('YYYY-MM-DDTHH:mm:ss'), read: false },
+  { id: 3, title: '새로운 멤버 초대', content: '김민준님이 "마케팅팀"에 합류했습니다.', date: dayjs().subtract(3, 'day').format('YYYY-MM-DDTHH:mm:ss'), read: true },
+  { id: 4, title: '서버 점검 안내', content: '오늘 오후 10시에 정기 서버 점검이 있습니다.', date: dayjs().subtract(10, 'day').format('YYYY-MM-DDTHH:mm:ss'), read: true },
+];
+
+const initialState = {
+  notifications: mockNotifications,
+  unreadCount: mockNotifications.filter(n => !n.read).length,
+};
+
+const notificationSlice = createSlice({
+  name: 'notifications',
+  initialState,
+  reducers: {
+    // 여기에 나중에 알림을 읽음 처리하는 등의 reducer를 추가할 수 있습니다.
+    markAsRead(state, action) {
+      const notification = state.notifications.find(n => n.id === action.payload);
+      if (notification) {
+        notification.read = true;
+        state.unreadCount = state.notifications.filter(n => !n.read).length;
+      }
+    },
+  },
+});
+
+export const { markAsRead } = notificationSlice.actions;
+export default notificationSlice.reducer; 

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -9,13 +9,19 @@ import {
   Main,
 } from "./MainLayout.styles";
 import { Outlet } from "react-router-dom";
+import NotificationsDrawer from "@/features/notifications/components/NotificationsDrawer";
 
 export default function MainLayout() {
   const isMobile = useMediaQuery("(max-width:600px)");
   const [mobileOpen, setMobileOpen] = useState(false);
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
 
   const handleDrawerToggle = () => {
     setMobileOpen((prev) => !prev);
+  };
+
+  const handleNotificationsToggle = () => {
+    setNotificationsOpen((prev) => !prev);
   };
 
   return (
@@ -32,14 +38,15 @@ export default function MainLayout() {
           onClose={handleDrawerToggle}
           ModalProps={{ keepMounted: true }}
         >
-          <Sidebar onClose={handleDrawerToggle} />
+          <Sidebar onClose={handleDrawerToggle} onNotificationsClick={handleNotificationsToggle} />
         </StyledDrawer>
       ) : (
-        <Sidebar onClose={() => {}} />
+        <Sidebar onClose={() => {}} onNotificationsClick={handleNotificationsToggle} />
       )}
       <Main>
         <Outlet />
       </Main>
+      <NotificationsDrawer open={notificationsOpen} onClose={handleNotificationsToggle} />
     </Root>
   );
 }

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { useMediaQuery } from "@mui/material";
+import { useSelector } from "react-redux";
 import MenuIcon from "@mui/icons-material/Menu";
 import Sidebar from "./Sidebar";
 import {
@@ -15,6 +16,7 @@ export default function MainLayout() {
   const isMobile = useMediaQuery("(max-width:600px)");
   const [mobileOpen, setMobileOpen] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const unreadCount = useSelector((state) => state.notifications.unreadCount);
 
   const handleDrawerToggle = () => {
     setMobileOpen((prev) => !prev);
@@ -38,10 +40,10 @@ export default function MainLayout() {
           onClose={handleDrawerToggle}
           ModalProps={{ keepMounted: true }}
         >
-          <Sidebar onClose={handleDrawerToggle} onNotificationsClick={handleNotificationsToggle} />
+          <Sidebar onClose={handleDrawerToggle} onNotificationsClick={handleNotificationsToggle} unreadCount={unreadCount} />
         </StyledDrawer>
       ) : (
-        <Sidebar onClose={() => {}} onNotificationsClick={handleNotificationsToggle} />
+        <Sidebar onClose={() => {}} onNotificationsClick={handleNotificationsToggle} unreadCount={unreadCount} />
       )}
       <Main>
         <Outlet />

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -9,6 +9,7 @@ import {
   Typography,
   Avatar,
   IconButton,
+  Badge,
 } from "@mui/material";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import MailOutlineRoundedIcon from "@mui/icons-material/MailOutlineRounded";
@@ -26,7 +27,7 @@ import {
   clearAuthState,
 } from "@/features/auth/authSlice";
 
-export default function Sidebar({ onClose, onNotificationsClick }) {
+export default function Sidebar({ onClose, onNotificationsClick, unreadCount }) {
   const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -67,7 +68,9 @@ export default function Sidebar({ onClose, onNotificationsClick }) {
             <Typography variant="subtitle1">{memberName || ""}</Typography>
           </div>
           <IconButton size="small" onClick={onNotificationsClick}>
-            <MailOutlineRoundedIcon fontSize="small" sx={{ color: 'grey.400' }} />
+            <Badge badgeContent={unreadCount} color="error">
+              <MailOutlineRoundedIcon fontSize="small" sx={{ color: 'grey.400' }} />
+            </Badge>
           </IconButton>
         </Box>
       </ProfileSection>

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -26,7 +26,7 @@ import {
   clearAuthState,
 } from "@/features/auth/authSlice";
 
-export default function Sidebar({ onClose }) {
+export default function Sidebar({ onClose, onNotificationsClick }) {
   const location = useLocation();
   const navigate = useNavigate();
   const dispatch = useDispatch();
@@ -66,7 +66,7 @@ export default function Sidebar({ onClose }) {
             </Typography>
             <Typography variant="subtitle1">{memberName || ""}</Typography>
           </div>
-          <IconButton size="small">
+          <IconButton size="small" onClick={onNotificationsClick}>
             <MailOutlineRoundedIcon fontSize="small" sx={{ color: 'grey.400' }} />
           </IconButton>
         </Box>

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -8,8 +8,10 @@ import {
   ListItemText,
   Typography,
   Avatar,
+  IconButton,
 } from "@mui/material";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
+import MailOutlineRoundedIcon from "@mui/icons-material/MailOutlineRounded";
 
 import {
   SidebarRoot,
@@ -57,12 +59,17 @@ export default function Sidebar({ onClose }) {
     <SidebarRoot>
       <ProfileSection>
         <Avatar src="/toss_logo.png" />
-        <div className="profile-text" style={{ marginLeft: 8 }}>
-          <Typography variant="body2">
-            {getRoleLabel(memberRole) || ""}
-          </Typography>
-          <Typography variant="subtitle1">{memberName || ""}</Typography>
-        </div>
+        <Box sx={{ display: 'flex', alignItems: 'center', flexGrow: 1, justifyContent: 'space-between' }}>
+          <div className="profile-text" style={{ marginLeft: 8 }}>
+            <Typography variant="body2">
+              {getRoleLabel(memberRole) || ""}
+            </Typography>
+            <Typography variant="subtitle1">{memberName || ""}</Typography>
+          </div>
+          <IconButton size="small">
+            <MailOutlineRoundedIcon fontSize="small" sx={{ color: 'grey.400' }} />
+          </IconButton>
+        </Box>
       </ProfileSection>
 
       <NavList>

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -11,6 +11,7 @@ import reviewReducer from "@/features/project/post/reviewSlice";
 import DashboardReducer from "@/features/dashboard/DashboardSlice";
 import logsReducer from "@/features/logs/logsSlice";
 import checklistReducer from "@/features/project/approval/checklistSlice";
+import notificationReducer from "@/features/notifications/notificationSlice";
 
 const preloadedAuth = (() => {
   try {
@@ -51,6 +52,7 @@ export const store = configureStore({
     dashboard: DashboardReducer,
     logs: logsReducer,
     checklist: checklistReducer,
+    notifications: notificationReducer,
   },
   preloadedState: {
     auth: preloadedAuth,

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,0 +1,34 @@
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import 'dayjs/locale/ko';
+
+// dayjs 플러그인 및 로케일 설정
+dayjs.extend(relativeTime);
+dayjs.locale('ko');
+
+/**
+ * 알림 날짜를 규칙에 맞게 포맷하는 함수
+ * @param {string} dateString - LocalDateTime 형식의 날짜 문자열
+ * @returns {string} 포맷된 날짜 문자열
+ */
+export const formatNotificationDate = (dateString) => {
+  if (!dateString) return '';
+  
+  const notificationDate = dayjs(dateString);
+  const now = dayjs();
+
+  // 오늘인 경우 (예: "3시간 전")
+  if (now.isSame(notificationDate, 'day')) {
+    return notificationDate.fromNow();
+  }
+  
+  const diffInDays = now.diff(notificationDate, 'day');
+
+  // 일주일 이내인 경우 (예: "3일 전")
+  if (diffInDays < 7) {
+    return `${diffInDays}일 전`;
+  }
+
+  // 일주일을 초과한 경우 (예: "2024-06-20")
+  return notificationDate.format('YYYY-MM-DD');
+}; 


### PR DESCRIPTION
## 📌 개요

- 알림 페이지 생성

## 🛠️ 변경 사항

- 알림 아이콘 추가 ( 사이드바 최상단에 위치 )
- 알림 페이지 생성 ( 기존 post 와 디자인 동일 )
- 알림 날짜에 대한 공통 js 추가 ( 오늘 날짜면 X시간전, 오늘이 아니면 X일전, 1주일이 넘으면 yyyy-MM-dd 형식노출)

## ✅ 주요 체크 포인트

- [ ] 알림 아이콘 기능작동 확인.
- [ ] 데이터가 없어서 mock 데이터 들어간 부분  api 연동시 삭제필요.
- [ ] api  구성에 따른 페이지 변경 필요. 
## 🔁 테스트 결과

- mock 데이터로 화면 확인.
![image](https://github.com/user-attachments/assets/e682aee7-747c-4523-bbcc-5f91b3ce3221)

## 🔗 연관된 이슈

#260 
