### PR TITLE
fix: 프로젝트 상세 상태,가격 필드 추가 #309

### DIFF
--- a/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
+++ b/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
@@ -6,11 +6,24 @@ import {
   Tooltip,
   Stack,
   Divider,
+  MenuItem,
 } from "@mui/material";
 import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
 import { CalendarTodayRounded, InfoOutlined } from "@mui/icons-material";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
+
+const STATUS_OPTIONS = [
+  { value: "CONTRACT", label: "결제" },
+  { value: "IN_PROGRESS", label: "진행" },
+  { value: "PAYMENT", label: "검수" },
+  { value: "COMPLETED", label: "완료" },
+];
+
+const getStatusLabel = (status) => {
+  const option = STATUS_OPTIONS.find(opt => opt.value === status);
+  return option ? option.label : status || "-";
+};
 
 export default function ProjectBasicInfoSectionContent({
   isEditable,
@@ -22,6 +35,10 @@ export default function ProjectBasicInfoSectionContent({
   setPeriodStart,
   periodEnd,
   setPeriodEnd,
+  projectAmount,
+  setProjectAmount,
+  projectStep,
+  setProjectStep,
   project,
 }) {
   return (
@@ -61,6 +78,32 @@ export default function ProjectBasicInfoSectionContent({
                   설명
                 </Typography>
                 <Typography variant="body1">{projectDetail || "-"}</Typography>
+              </>
+            )}
+          </Grid>
+
+          <Grid item xs={12} sm={isEditable ? 12 : 6}>
+            {isEditable ? (
+              <TextField
+                select
+                label="프로젝트 상태"
+                value={projectStep}
+                onChange={(e) => setProjectStep(e.target.value)}
+                fullWidth
+                required
+              >
+                {STATUS_OPTIONS.map((opt) => (
+                  <MenuItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </MenuItem>
+                ))}
+              </TextField>
+            ) : (
+              <>
+                <Typography variant="body2" color="text.secondary">
+                  프로젝트 상태
+                </Typography>
+                <Typography variant="body1">{getStatusLabel(project?.step)}</Typography>
               </>
             )}
           </Grid>
@@ -116,8 +159,16 @@ export default function ProjectBasicInfoSectionContent({
           </Grid>
 
           <Grid item xs={12} sm={isEditable ? 12 : 6}>
-            {/* 읽기모드에서만 프로젝트 금액 노출 */}
-            {!isEditable && (
+            {isEditable ? (
+              <TextField
+                label="프로젝트 금액(만원)"
+                value={projectAmount}
+                onChange={(e) => setProjectAmount(e.target.value)}
+                fullWidth
+                type="number"
+                inputProps={{ min: 0 }}
+              />
+            ) : (
               <>
                 <Typography variant="body2" color="text.secondary">
                   프로젝트 금액(만원)

--- a/src/features/project/home/hooks/useProjectDetailSections.jsx
+++ b/src/features/project/home/hooks/useProjectDetailSections.jsx
@@ -22,6 +22,10 @@ export default function useProjectDetailSections(
   setPeriodStart,
   periodEnd,
   setPeriodEnd,
+  projectAmount,
+  setProjectAmount,
+  projectStep,
+  setProjectStep,
   setStepEdited,
   setStepSaveFn
 ) {
@@ -54,6 +58,10 @@ export default function useProjectDetailSections(
           setPeriodStart={setPeriodStart}
           periodEnd={periodEnd}
           setPeriodEnd={setPeriodEnd}
+          projectAmount={projectAmount}
+          setProjectAmount={setProjectAmount}
+          projectStep={projectStep}
+          setProjectStep={setProjectStep}
         />
       ),
     },

--- a/src/features/project/home/pages/ProjectDetailPage.jsx
+++ b/src/features/project/home/pages/ProjectDetailPage.jsx
@@ -36,6 +36,8 @@ export default function ProjectDetailPage() {
   const [projectDetail, setProjectDetail] = useState("");
   const [periodStart, setPeriodStart] = useState("");
   const [periodEnd, setPeriodEnd] = useState("");
+  const [projectAmount, setProjectAmount] = useState("");
+  const [projectStep, setProjectStep] = useState("");
 
   const [isAddStepOpen, setIsAddStepOpen] = useState(false);
   const [newStepName, setNewStepName] = useState("");
@@ -57,6 +59,8 @@ export default function ProjectDetailPage() {
       setProjectDetail(project.detail || "");
       setPeriodStart(dayjs(project.startAt).format("YYYY-MM-DD") || "");
       setPeriodEnd(dayjs(project.endAt).format("YYYY-MM-DD") || "");
+      setProjectAmount(project.projectAmount ?? "");
+      setProjectStep(project.step || "CONTRACT");
     }
   }, [loading, project, error, navigate]);
 
@@ -66,9 +70,11 @@ export default function ProjectDetailPage() {
       project.name !== projectName ||
       project.detail !== projectDetail ||
       dayjs(project.startAt).format("YYYY-MM-DD") !== periodStart ||
-      dayjs(project.endAt).format("YYYY-MM-DD") !== periodEnd
+      dayjs(project.endAt).format("YYYY-MM-DD") !== periodEnd ||
+      project.projectAmount !== projectAmount ||
+      project.step !== projectStep
     );
-  }, [project, projectName, projectDetail, periodStart, periodEnd]);
+  }, [project, projectName, projectDetail, periodStart, periodEnd, projectAmount, projectStep]);
 
   const isEdited = isInfoEdited || stepEdited;
 
@@ -78,6 +84,8 @@ export default function ProjectDetailPage() {
     setProjectDetail(project.detail);
     setPeriodStart(dayjs(project.startAt).format("YYYY-MM-DD"));
     setPeriodEnd(dayjs(project.endAt).format("YYYY-MM-DD"));
+    setProjectAmount(project.projectAmount ?? "");
+    setProjectStep(project.step || "CONTRACT");
   };
 
   const handleSave = async () => {
@@ -89,6 +97,8 @@ export default function ProjectDetailPage() {
           detail: projectDetail,
           ...(periodStart && { startAt: `${periodStart}T09:00:00` }),
           ...(periodEnd && { endAt: `${periodEnd}T18:00:00` }),
+          projectAmount: projectAmount === "" ? null : Number(projectAmount),
+          step: projectStep,
           deleted: false,
         };
         await dispatch(updateProject(payload)).unwrap();
@@ -138,6 +148,10 @@ export default function ProjectDetailPage() {
     setPeriodStart,
     periodEnd,
     setPeriodEnd,
+    projectAmount,
+    setProjectAmount,
+    projectStep,
+    setProjectStep,
     setStepEdited,
     setStepSaveFn
   );


### PR DESCRIPTION
## 📌 개요

-프로젝트 상세 상태,가격 필드 추가 #309

## 🛠️ 변경 사항

- 프로젝트 상세페이지 수정폼 일때 상태와 가격 필드 추가.

## ✅ 주요 체크 포인트

- [ ] 프로젝트 상세 페이지 값노출 확인.

## 🔁 테스트 결과

화면테스트

## 🔗 연관된 이슈
#309 