### PR TITLE
bug : 게시글 생성시 버그 수정

### DIFF
--- a/src/api/post.js
+++ b/src/api/post.js
@@ -161,3 +161,25 @@ export function uploadFileToS3(presignedUrl, file) {
     },
   });
 }
+
+/**
+ * 게시글 첨부파일 일괄 활성화
+ * POST /api/posts/attachment/bulk-active
+ *
+ * @param {{ postId: string; postAttachmentIds: string[]; }} data
+ * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<PostAttachmentBulkActiveResponse>
+ */
+export function bulkActivateAttachments(data) {
+  return api.post("/api/posts/attachment/bulk-active", data);
+}
+
+/**
+ * 게시글의 모든 첨부파일 정리 (비활성화된 파일들 삭제)
+ * DELETE /api/posts/{postId}/attachments/cleanup
+ *
+ * @param {string} postId - 게시글 UUID
+ * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<PostAttachmentCleanupResponse>
+ */
+export function cleanupPostAttachments(postId) {
+  return api.delete(`/api/posts/${postId}/attachments/cleanup`);
+}

--- a/src/features/project/post/postSlice.js
+++ b/src/features/project/post/postSlice.js
@@ -238,6 +238,36 @@ export const deleteAttachment = createAsyncThunk(
   }
 );
 
+// 13) 첨부파일 일괄 활성화
+export const bulkActivateAttachments = createAsyncThunk(
+  "post/bulkActivateAttachments",
+  async ({ postId, postAttachmentIds }, thunkAPI) => {
+    try {
+      const response = await postAPI.bulkActivateAttachments({ postId, postAttachmentIds });
+      return response.data.data;
+    } catch (err) {
+      return thunkAPI.rejectWithValue(
+        err.response?.data || "첨부파일 일괄 활성화 실패"
+      );
+    }
+  }
+);
+
+// 14) 게시글 첨부파일 정리
+export const cleanupPostAttachments = createAsyncThunk(
+  "post/cleanupPostAttachments",
+  async (postId, thunkAPI) => {
+    try {
+      await postAPI.cleanupPostAttachments(postId);
+      return postId;
+    } catch (err) {
+      return thunkAPI.rejectWithValue(
+        err.response?.data || "첨부파일 정리 실패"
+      );
+    }
+  }
+);
+
 const postSlice = createSlice({
   name: "post",
   initialState: {
@@ -434,6 +464,32 @@ const postSlice = createSlice({
         // 삭제된 첨부파일 ID와 일치하는 항목 제거 (필요한 경우)
       })
       .addCase(deleteAttachment.rejected, (state, action) => {
+        state.attachmentLoading = false;
+        state.attachmentError = action.payload;
+      })
+
+      // bulkActivateAttachments
+      .addCase(bulkActivateAttachments.pending, (state) => {
+        state.attachmentLoading = true;
+        state.attachmentError = null;
+      })
+      .addCase(bulkActivateAttachments.fulfilled, (state) => {
+        state.attachmentLoading = false;
+      })
+      .addCase(bulkActivateAttachments.rejected, (state, action) => {
+        state.attachmentLoading = false;
+        state.attachmentError = action.payload;
+      })
+
+      // cleanupPostAttachments
+      .addCase(cleanupPostAttachments.pending, (state) => {
+        state.attachmentLoading = true;
+        state.attachmentError = null;
+      })
+      .addCase(cleanupPostAttachments.fulfilled, (state) => {
+        state.attachmentLoading = false;
+      })
+      .addCase(cleanupPostAttachments.rejected, (state, action) => {
         state.attachmentLoading = false;
         state.attachmentError = action.payload;
       });


### PR DESCRIPTION
## 📌 개요
- 게시글 파일 첨부 시 newPostId 재사용으로 인한 고아 파일 연결 문제를 해결했습니다.
- 게시글 생성창 접속 시마다 새로운 newPostId를 발급하여 사용자별/세션별 완전 분리를 보장합니다.

## 🛠️ 변경 사항
- CreatePostDrawer 컴포넌트에서 독립적인 newPostId 발급 로직 추가
- 게시글 목록 페이지에서 newPostId 사전 발급 로직 제거
- 파일 업로드 시 Active API 호출 제거 (게시글 생성 성공 후 일괄 처리)
- 게시글 생성 완료 후 업로드된 파일들을 순차적으로 활성화하는 로직 추가

## ✅ 주요 체크 포인트
- [ ] CreatePostDrawer 컴포넌트의 newPostId 생성 타이밍 및 독립성 확인
- [ ] 파일 업로드 플로우에서 Active API 호출이 제거되었는지 확인
- [ ] 게시글 생성 성공 후 파일 활성화 로직이 정상 동작하는지 확인
- [ ] 사용자별 newPostId 분리로 타인 파일 연결 방지가 되는지 확인
- [ ] 로그아웃 후 다른 사용자 접속 시 newPostId 독립성 보장 확인

## 🔁 테스트 결과
### 시나리오 1: 같은 사용자 반복 접속
1. 게시글 생성창 열기 → 파일 업로드 → 취소
2. 다시 게시글 생성창 열기 → 새 파일 업로드 → 게시글 생성
3. **결과**: 이전 고아 파일이 연결되지 않고 새 파일만 게시글에 첨부됨 ✅

### 시나리오 2: 다른 사용자 접속
1. User A: 파일 업로드 후 게시글 생성 취소
2. 로그아웃 후 User B 접속
3. User B: 파일 업로드 후 게시글 생성
4. **결과**: User A의 고아 파일이 User B 게시글에 연결되지 않음 ✅

### 시나리오 3: 파일 활성화 타이밍
1. 파일 업로드 시 Active API 호출되지 않는지 확인 ✅
2. 게시글 생성 완료 후 파일별 Active API 순차 호출 확인 ✅

## 🔗 연관된 이슈
- #XXX - 게시글 파일 첨부 시 고아 파일 연결 문제

## 📑 레퍼런스
- [[게시글 생성 플로우 시퀀스 다이어그램](https://claude.ai/chat/%EB%A7%81%ED%81%AC)](링크)
- [[파일 업로드 API 문서](https://claude.ai/chat/%EB%A7%81%ED%81%AC)](링크)
- [[스케줄러 고아 파일 정리 로직](https://claude.ai/chat/%EB%A7%81%ED%81%AC)](링크)