### PR TITLE
feat : 첨부파일 일괄 활성화 API 적용

### DIFF
--- a/src/api/post.js
+++ b/src/api/post.js
@@ -95,14 +95,16 @@ export function reissueAttachmentUploadUrl(data) {
 }
 
 /**
- * 게시글 파일 업로드 완료 상태 변경
- * POST /api/posts/attachment/active
+ * 게시글 파일 업로드 완료 상태 변경 (개별)
+ * POST /api/posts/attachments/active
  *
  * @param {{ postAttachmentId: string; active: boolean; }} data
  * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<PostAttachmentActiveResponse>
  */
 export function setAttachmentActive(data) {
-  return api.post("/api/posts/attachment/active", data);
+  return api.post("/api/posts/attachments/active", {
+    postAttachments: [data]
+  });
 }
 
 /**
@@ -164,13 +166,16 @@ export function uploadFileToS3(presignedUrl, file) {
 
 /**
  * 게시글 첨부파일 일괄 활성화
- * POST /api/posts/attachment/bulk-active
+ * POST /api/posts/attachments/active
  *
- * @param {{ postId: string; postAttachmentIds: string[]; }} data
+ * @param {{ postId: string; }} data
  * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<PostAttachmentBulkActiveResponse>
  */
 export function bulkActivateAttachments(data) {
-  return api.post("/api/posts/attachment/bulk-active", data);
+  return api.post("/api/posts/attachments/active", {
+    postId: data.postId,
+    active: true
+  });
 }
 
 /**

--- a/src/features/project/post/postSlice.js
+++ b/src/features/project/post/postSlice.js
@@ -241,9 +241,9 @@ export const deleteAttachment = createAsyncThunk(
 // 13) 첨부파일 일괄 활성화
 export const bulkActivateAttachments = createAsyncThunk(
   "post/bulkActivateAttachments",
-  async ({ postId, postAttachmentIds }, thunkAPI) => {
+  async ({ postId }, thunkAPI) => {
     try {
-      const response = await postAPI.bulkActivateAttachments({ postId, postAttachmentIds });
+      const response = await postAPI.bulkActivateAttachments({ postId });
       return response.data.data;
     } catch (err) {
       return thunkAPI.rejectWithValue(


### PR DESCRIPTION
# 📌 개요
게시글 첨부파일 일괄 활성화 API 구현으로 성능 최적화

# 🛠️ 변경 사항
- 첨부파일 개별 활성화 API를 일괄 활성화 API로 변경
    - API 엔드포인트 변경 /api/posts/attachment/active → /api/posts/attachments/active
    - 요청 파라미터 간소화: postAttachmentIds[] → postId + active
- 네트워크 요청 횟수 대폭 감소 (파일 개수만큼 N번 → 1번)

# ✅ 주요 체크 포인트
- [x] API 요청 바디 형식 변경: { postId, active } 구조 확인
- [x] 게시글 생성 후 첨부파일 일괄 활성화 로직 검토
- [x] UUID 독립성: 게시글 생성창마다 새로운 postId 발급되는지 확인

🔁 테스트 결과

# 기능 테스트
✅ 파일 업로드 후 게시글 생성 → 모든 첨부파일 활성화 확인

# 🔗 연관된 이슈
- #314 
