### PR TITLE
[feat] 알림 Drawer 내 무한 스크롤 기능 구현 (IntersectionObserver 방식)(#312)

### DIFF
--- a/src/features/notifications/components/NotificationsDrawer.jsx
+++ b/src/features/notifications/components/NotificationsDrawer.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import {
   Box,
   Typography,
@@ -13,36 +13,77 @@ import CloseIcon from "@mui/icons-material/Close";
 import NotificationsIcon from "@mui/icons-material/Notifications";
 import { useDispatch, useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import { fetchNotifications } from "@/features/notifications/notificationSlice";
+import {
+  fetchNotifications,
+  markNotificationsAsRead,
+  clearNotifications,
+} from "@/features/notifications/notificationSlice";
 import { getActionLabel, getTargetLabel } from "@/utils/notificationLabelMap";
 import NotificationContentBox from "../components/NotificationContentBox";
 import { formatNotificationDate } from "@/utils/dateUtils";
-import { markNotificationsAsRead } from "../notificationSlice";
 
 export default function NotificationsDrawer({ open, onClose }) {
   const theme = useTheme();
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const bottomRef = useRef(null);
+  const scrollBoxRef = useRef(null);
   const isMobile = useMediaQuery(theme.breakpoints.down("sm"));
 
-  const { notifications = [], loading } = useSelector(
-    (state) => state.notification
-  );
+  const {
+    notifications = [],
+    loading,
+    page,
+    hasMore,
+  } = useSelector((state) => state.notification);
+
+  console.log("notifications", notifications);
 
   const SIDEBAR_WIDTH = 216;
   const DRAWER_WIDTH = 360;
 
   useEffect(() => {
     if (open) {
-      dispatch(fetchNotifications({ page: 1 }));
+      dispatch(clearNotifications());
+      dispatch(fetchNotifications(1));
     }
   }, [open, dispatch]);
+
+  useEffect(() => {
+    const target = bottomRef.current;
+    const root = scrollBoxRef.current;
+    if (!target || !root || !hasMore || !open) return;
+
+    let fetching = false;
+
+    const observer = new IntersectionObserver(
+      async ([entry]) => {
+        if (entry.isIntersecting && !fetching && !loading) {
+          fetching = true;
+          try {
+            await dispatch(fetchNotifications(page)).unwrap();
+          } catch (e) {
+            console.error("Failed to fetch notifications:", e);
+          } finally {
+            fetching = false;
+          }
+        }
+      },
+      {
+        root,
+        threshold: 0.1,
+        rootMargin: "0px 0px 100px 0px",
+      }
+    );
+
+    observer.observe(target);
+    return () => observer.disconnect();
+  }, [notifications, hasMore, open, dispatch, loading, page]);
 
   const handleNotificationClick = (notif) => {
     if (!notif.isRead) {
       dispatch(markNotificationsAsRead(notif.id));
     }
-
     if (notif.targetType === "PROJECT_CHECK_LIST") {
       navigate(
         `/projects/${notif.projectId}/approvals?targetId=${notif.targetId}`
@@ -70,7 +111,6 @@ export default function NotificationsDrawer({ open, onClose }) {
           height: "100%",
           bgcolor: "background.paper",
           boxShadow: theme.shadows[4],
-          clipPath: "inset(0px -24px 0px 0px)",
           borderTopRightRadius: 12,
           borderBottomRightRadius: 12,
           transform: open ? "translateX(0)" : "translateX(-100%)",
@@ -90,7 +130,7 @@ export default function NotificationsDrawer({ open, onClose }) {
         >
           <Box display="flex" alignItems="center" gap={1}>
             <NotificationsIcon sx={{ fontSize: 20, color: "text.primary" }} />
-            <Typography variant="h6" fontWeight={600} color="text.primary">
+            <Typography variant="h6" fontWeight={600}>
               알림
             </Typography>
           </Box>
@@ -99,81 +139,92 @@ export default function NotificationsDrawer({ open, onClose }) {
           </IconButton>
         </Box>
 
-        <Stack spacing={1.5} px={2} pb={2}>
-          {loading ? (
-            <Box sx={{ textAlign: "center", mt: 6 }}>
-              <CircularProgress />
-            </Box>
-          ) : notifications.length === 0 ? (
-            <Box sx={{ textAlign: "center", mt: 6 }}>
-              <Typography variant="body2" color="text.secondary">
-                새로운 알림이 없습니다.
-              </Typography>
-            </Box>
-          ) : (
-            notifications.map((notif) => (
-              <Paper
-                key={notif.id}
-                elevation={0}
-                onClick={() => handleNotificationClick(notif)}
-                sx={{
-                  cursor: "pointer",
-                  borderRadius: 3,
-                  px: 2,
-                  py: 2,
-                  bgcolor: notif.isRead
-                    ? theme.palette.background.default
-                    : theme.palette.grey[100],
-                  border: `1px solid ${theme.palette.divider}`,
-                  transition: "all 0.2s ease",
-                  "&:hover": {
-                    backgroundColor: theme.palette.grey[200],
-                  },
-                }}
-              >
-                <Stack spacing={1}>
-                  <Box display="flex" alignItems="flex-start" gap={1}>
-                    {!notif.isRead && (
-                      <Box
-                        sx={{
-                          width: 8,
-                          height: 8,
-                          mt: "6px",
-                          borderRadius: "50%",
-                          bgcolor: "text.primary",
-                          flexShrink: 0,
-                        }}
-                      />
-                    )}
+        {/* 알림 목록 */}
+        <Box
+          ref={scrollBoxRef}
+          sx={{ overflowY: "auto", flex: 1, px: 2, pb: 2 }}
+        >
+          <Stack spacing={1.5}>
+            {notifications.length === 0 && !loading ? (
+              <Box sx={{ textAlign: "center", mt: 6 }}>
+                <Typography variant="body2" color="text.secondary">
+                  새로운 알림이 없습니다.
+                </Typography>
+              </Box>
+            ) : (
+              notifications?.map((notif) => (
+                <Paper
+                  key={notif.id}
+                  elevation={0}
+                  onClick={() => handleNotificationClick(notif)}
+                  sx={{
+                    cursor: "pointer",
+                    borderRadius: 3,
+                    px: 2,
+                    py: 2,
+                    bgcolor: notif.isRead
+                      ? theme.palette.background.default
+                      : theme.palette.grey[100],
+                    border: `1px solid ${theme.palette.divider}`,
+                    transition: "all 0.2s ease",
+                    "&:hover": {
+                      backgroundColor: theme.palette.grey[200],
+                    },
+                  }}
+                >
+                  <Stack spacing={1}>
+                    <Box display="flex" alignItems="flex-start" gap={1}>
+                      {!notif.isRead && (
+                        <Box
+                          sx={{
+                            width: 8,
+                            height: 8,
+                            mt: "6px",
+                            borderRadius: "50%",
+                            bgcolor: "text.primary",
+                            flexShrink: 0,
+                          }}
+                        />
+                      )}
+                      <Typography
+                        variant="body2"
+                        fontWeight={500}
+                        color="text.primary"
+                        sx={{ wordBreak: "keep-all", lineHeight: 1.6 }}
+                      >
+                        {`${notif.actorName}님이 ${getTargetLabel(
+                          notif.targetType
+                        )}에 대해 ${getActionLabel(
+                          notif.actionType
+                        )}을(를) 남겼습니다.`}
+                      </Typography>
+                    </Box>
+
+                    <NotificationContentBox
+                      targetType={notif.targetType}
+                      content={notif.content}
+                    />
+
                     <Typography
-                      variant="body2"
-                      fontWeight={500}
-                      color="text.primary"
-                      sx={{ wordBreak: "keep-all", lineHeight: 1.6 }}
+                      variant="caption"
+                      color="text.secondary"
+                      textAlign="right"
                     >
-                      {`${notif.actorName}님이 ${getTargetLabel(notif.targetType)}에 대해 ${getActionLabel(
-                        notif.actionType
-                      )}을(를) 남겼습니다.`}
+                      {formatNotificationDate(notif.createdAt)}
                     </Typography>
-                  </Box>
+                  </Stack>
+                </Paper>
+              ))
+            )}
 
-                  <NotificationContentBox
-                    targetType={notif.targetType}
-                    content={notif.content}
-                  />
-
-                  <Typography
-                    variant="caption"
-                    color="text.secondary"
-                    textAlign="right"
-                  >
-                    {formatNotificationDate(notif.createdAt)}
-                  </Typography>
-                </Stack>
-              </Paper>
-            ))
-          )}
-        </Stack>
+            <div ref={bottomRef} style={{ height: 10 }} />
+            {loading && (
+              <Box sx={{ textAlign: "center", mt: 2, mb: 2 }}>
+                <CircularProgress size={24} />
+              </Box>
+            )}
+          </Stack>
+        </Box>
       </Box>
     </Box>
   );

--- a/src/features/notifications/notificationSlice.js
+++ b/src/features/notifications/notificationSlice.js
@@ -1,26 +1,36 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import { getNotifications, readNotification } from "@/api/notification";
 
-// 알림 목록 조회 Thunk
 export const fetchNotifications = createAsyncThunk(
-  "notification/fetchList",
-  async ({ page, isRead }, { rejectWithValue }) => {
+  "notifications/fetch",
+  async (page, { rejectWithValue }) => {
     try {
-      const res = await getNotifications(page, isRead);
-      return res.data.data.notificationSelectWebResponses; // NotificationListSelectWebResponse.notifications
+      const res = await getNotifications(page);
+      return res.data.data;
     } catch (err) {
       return rejectWithValue(err.response?.data || err.message);
     }
   }
 );
 
-// 알림 읽음 처리 Thunk
+export const refreshNotifications = createAsyncThunk(
+  "notifications/refresh",
+  async (_, { rejectWithValue }) => {
+    try {
+      const res = await getNotifications(1);
+      return res.data;
+    } catch (err) {
+      return rejectWithValue(err.response?.data || err.message);
+    }
+  }
+);
+
 export const markNotificationsAsRead = createAsyncThunk(
   "notification/markAsRead",
   async (id, { rejectWithValue }) => {
     try {
       const res = await readNotification({ id });
-      return res.data.data; // NotificationReadWebResponse
+      return res.data.data;
     } catch (err) {
       return rejectWithValue(err.response?.data || err.message);
     }
@@ -28,43 +38,52 @@ export const markNotificationsAsRead = createAsyncThunk(
 );
 
 const notificationSlice = createSlice({
-  name: "notification",
+  name: "notifications",
   initialState: {
     notifications: [],
     loading: false,
     error: null,
+    page: 1,
+    hasMore: true,
     readStatus: null,
   },
   reducers: {
-    clearNotifications: (state) => {
+    clearNotifications(state) {
       state.notifications = [];
+      state.page = 1;
+      state.hasMore = true;
+      state.loading = false;
       state.error = null;
     },
   },
   extraReducers: (builder) => {
     builder
-      // 알림 목록 조회
       .addCase(fetchNotifications.pending, (state) => {
         state.loading = true;
-        state.error = null;
       })
       .addCase(fetchNotifications.fulfilled, (state, action) => {
+        const data = action.payload.notificationSelectWebResponses || [];
+        if (state.page === 1) {
+          state.notifications = data;
+        } else {
+          state.notifications = [...state.notifications, ...data];
+        }
+        state.page += 1;
+        state.hasMore = data.length === 10;
         state.loading = false;
-        state.notifications = action.payload;
       })
       .addCase(fetchNotifications.rejected, (state, action) => {
         state.loading = false;
         state.error = action.payload;
+        state.hasMore = false;
       })
 
-      // 알림 읽음 처리
       .addCase(markNotificationsAsRead.pending, (state) => {
         state.readStatus = "loading";
       })
       .addCase(markNotificationsAsRead.fulfilled, (state, action) => {
         state.readStatus = "success";
         const readId = action.payload.id;
-        // 읽은 항목의 isRead 값을 true로 변경
         state.notifications = state.notifications.map((n) =>
           n.id === readId ? { ...n, isRead: true } : n
         );
@@ -72,7 +91,10 @@ const notificationSlice = createSlice({
       .addCase(markNotificationsAsRead.rejected, (state, action) => {
         state.readStatus = "error";
         state.error = action.payload;
-      });
+      })
+
+      .addCase(refreshNotifications.fulfilled, () => {})
+      .addCase(refreshNotifications.rejected, () => {});
   },
 });
 

--- a/src/hooks/useNotificationPolling.js
+++ b/src/hooks/useNotificationPolling.js
@@ -1,25 +1,23 @@
-// src/hooks/useNotificationPolling.js
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchNotifications } from "@/features/notifications/notificationSlice";
+import { refreshNotifications } from "@/features/notifications/notificationSlice";
 
 export default function useNotificationPolling(
-  intervalMs = 18000,
-  page = 1,
-  isRead
+  enabled = true,
+  intervalMs = 18000
 ) {
   const dispatch = useDispatch();
-  const isLoggedIn = useSelector((state) => !!state.auth?.user); // 또는 state.auth.isLoggedIn
+  const isLoggedIn = useSelector((state) => !!state.auth?.user);
 
   useEffect(() => {
-    if (!isLoggedIn) return;
+    if (!enabled || !isLoggedIn) return;
 
-    dispatch(fetchNotifications({ page, isRead }));
+    dispatch(refreshNotifications());
 
     const timerId = setInterval(() => {
-      dispatch(fetchNotifications({ page, isRead }));
+      dispatch(refreshNotifications());
     }, intervalMs);
 
     return () => clearInterval(timerId);
-  }, [dispatch, intervalMs, page, isRead, isLoggedIn]);
+  }, [dispatch, enabled, isLoggedIn, intervalMs]);
 }

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -14,10 +14,11 @@ import NotificationsDrawer from "@/features/notifications/components/Notificatio
 import useNotificationPolling from "@/hooks/useNotificationPolling";
 
 export default function MainLayout() {
-  useNotificationPolling();
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+
+  useNotificationPolling(!notificationsOpen);
   const isMobile = useMediaQuery("(max-width:600px)");
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [notificationsOpen, setNotificationsOpen] = useState(false);
 
   const handleDrawerToggle = () => {
     setMobileOpen((prev) => !prev);


### PR DESCRIPTION
## 📌 개요

* 알림 Drawer 내에서 스크롤을 내릴 때 자동으로 다음 알림 페이지를 불러오는 **무한 스크롤 기능**을 구현했습니다.
* 기존 페이지 덮어쓰지 않고 이어 붙는 방식으로 UX 개선했습니다.

---

## 🛠️ 변경 사항

* Drawer 내부 컨테이너에 `IntersectionObserver` 적용
* 무한 스크롤 트리거용 `bottomRef` 요소 추가
* `fetchNotifications(page)` 호출 구조로 수정 (쿼리파람 누락 방지)
* `notificationSlice`에서 `page === 1`이면 덮어쓰기, 이후는 이어붙기 처리
* API 실패 시 무한 반복 방지를 위해 `hasMore = false` 설정
* 중복 호출 방지를 위한 `fetching` 플래그 적용

---

## ✅ 주요 체크 포인트

* [ ] 옵저버가 정확히 동작하는지 (`scrollBoxRef` 기준으로)
* [ ] `fetchNotifications` 호출 시 `page`가 제대로 전달되는지
* [ ] 백엔드에서 쿼리 파라미터가 정상적으로 처리되고 있는지
* [ ] 빠르게 스크롤 시에도 API가 중복 호출되지 않는지

---

## 🔁 테스트 결과

* 알림이 20개 이상인 테스트 계정에서 Drawer를 열고 하단까지 스크롤 → 자동으로 다음 페이지 호출됨
* 빠르게 스크롤해도 API가 1회만 호출되고 중복 요청 없음
* 첫 페이지일 경우 기존 알림 목록이 초기화되며 정상 동작함
* 마지막 페이지 도달 시 더 이상 요청되지 않음 (`hasMore = false`)

---

## 🔗 연관된 이슈

* #267 
* #312 

---

## 📑 레퍼런스

* [`[MDN - IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)`](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver)
* [`[Medium - Infinite scroll with React](https://blog.bitsrc.io/using-the-intersection-observer-api-to-implement-infinite-scroll-in-a-react-app-a2a250c12c62)`](https://blog.bitsrc.io/using-the-intersection-observer-api-to-implement-infinite-scroll-in-a-react-app-a2a250c12c62)
