### PR TITLE
[feat] 게시글 작성에 이미지 첨부를 파일 첨부로 확장

### DIFF
--- a/src/features/project/post/components/CreatePostDrawer.jsx
+++ b/src/features/project/post/components/CreatePostDrawer.jsx
@@ -22,7 +22,10 @@ import {
   Avatar,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import { InfoOutlined, CloudUpload, Delete, AttachFile, ZoomIn, Refresh } from "@mui/icons-material";
+import { 
+  InfoOutlined, CloudUpload, Delete, AttachFile, ZoomIn, Refresh,
+  PictureAsPdf, Description, TableChart, Archive, Code, Movie, MusicNote, Image
+} from "@mui/icons-material";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
@@ -58,18 +61,59 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
   };
 
-  // 파일 타입 검증 함수
-  const isValidImageType = (file) => {
-    const allowedTypes = [
-      'image/jpeg',
-      'image/jpg', 
-      'image/png',
-      'image/gif',
-      'image/webp',
-      'image/bmp',
-      'image/svg+xml'
+  // 파일 타입별 아이콘 반환 함수
+  const getFileIcon = (fileName, fileType) => {
+    const extension = fileName.toLowerCase().split('.').pop();
+    
+    // 이미지 파일
+    if (fileType.startsWith('image/')) {
+      return <Image color="primary" />;
+    }
+    
+    // 문서 파일
+    if (['pdf'].includes(extension)) {
+      return <PictureAsPdf color="error" />;
+    }
+    if (['doc', 'docx', 'txt', 'rtf'].includes(extension)) {
+      return <Description color="primary" />;
+    }
+    if (['xls', 'xlsx', 'csv'].includes(extension)) {
+      return <TableChart color="success" />;
+    }
+    
+    // 압축 파일
+    if (['zip', 'rar', '7z', 'tar', 'gz'].includes(extension)) {
+      return <Archive color="warning" />;
+    }
+    
+    // 코드 파일
+    if (['js', 'ts', 'jsx', 'tsx', 'html', 'css', 'json', 'xml'].includes(extension)) {
+      return <Code color="info" />;
+    }
+    
+    // 동영상 파일
+    if (['mp4', 'avi', 'mov', 'wmv', 'flv', 'mkv'].includes(extension)) {
+      return <Movie color="secondary" />;
+    }
+    
+    // 오디오 파일
+    if (['mp3', 'wav', 'flac', 'aac', 'ogg'].includes(extension)) {
+      return <MusicNote color="secondary" />;
+    }
+    
+    // 기본 파일 아이콘
+    return <AttachFile color="action" />;
+  };
+
+  // 파일 타입 검증 함수 (위험한 파일 확장자 차단)
+  const isValidFileType = (file) => {
+    const dangerousExtensions = [
+      '.exe', '.bat', '.cmd', '.com', '.pif', '.scr', '.vbs', '.js', '.jar',
+      '.app', '.deb', '.pkg', '.rpm', '.dmg', '.msi', '.run', '.sh'
     ];
-    return allowedTypes.includes(file.type);
+    
+    const fileName = file.name.toLowerCase();
+    return !dangerousExtensions.some(ext => fileName.endsWith(ext));
   };
 
   // 파일 검증 함수
@@ -82,9 +126,9 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
       errors.push(`파일 크기가 5MB를 초과합니다. (${formatFileSize(file.size)})`);
     }
 
-    // 파일 타입 검증 (이미지만)
-    if (!isValidImageType(file)) {
-      errors.push('이미지 파일만 업로드 가능합니다. (JPEG, PNG, GIF, WebP, BMP, SVG)');
+    // 파일 타입 검증 (위험한 파일 차단)
+    if (!isValidFileType(file)) {
+      errors.push('보안상 위험한 파일 형식입니다. (실행 파일, 스크립트 등은 업로드할 수 없습니다)');
     }
 
     return errors;
@@ -518,7 +562,7 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
                     <Typography variant="subtitle1" fontWeight={600}>
                       4. 파일 첨부
                     </Typography>
-                    <Tooltip title="이미지 파일만 첨부 가능합니다. (JPEG, PNG, GIF, WebP, BMP, SVG, 최대 5MB)">
+                    <Tooltip title="모든 파일 형식 첨부 가능합니다. (최대 5MB, 실행파일 제외)">
                       <InfoOutlined fontSize="small" color="action" />
                     </Tooltip>
                   </Stack>
@@ -531,7 +575,7 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
                       onChange={handleFileSelect}
                       style={{ display: 'none' }}
                       id="file-upload"
-                      accept="image/jpeg,image/jpg,image/png,image/gif,image/webp,image/bmp,image/svg+xml"
+                      accept="*"
                     />
                     <label htmlFor="file-upload">
                       <Button 
@@ -576,11 +620,11 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
                           }}
                         >
                           <Stack direction="row" alignItems="center" spacing={2}>
-                            {/* 이미지 미리보기 썸네일 */}
+                            {/* 파일 아이콘/썸네일 */}
                             <Box
                               sx={{
-                                width: 60,
-                                height: 60,
+                                width: 48,
+                                height: 48,
                                 borderRadius: 1,
                                 overflow: 'hidden',
                                 border: '1px solid',
@@ -589,13 +633,13 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
                                 display: 'flex',
                                 alignItems: 'center',
                                 justifyContent: 'center',
-                                cursor: 'pointer',
-                                '&:hover': {
+                                cursor: file.type.startsWith('image/') ? 'pointer' : 'default',
+                                '&:hover': file.type.startsWith('image/') ? {
                                   borderColor: 'primary.main',
                                   opacity: 0.8
-                                }
+                                } : {}
                               }}
-                              onClick={() => handlePreviewOpen(file)}
+                              onClick={() => file.type.startsWith('image/') && handlePreviewOpen(file)}
                             >
                               {file.type.startsWith('image/') ? (
                                 <img
@@ -608,7 +652,7 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
                                   }}
                                 />
                               ) : (
-                                <AttachFile color="action" />
+                                getFileIcon(file.name, file.type)
                               )}
                             </Box>
                             

--- a/src/features/project/post/components/CreatePostDrawer.jsx
+++ b/src/features/project/post/components/CreatePostDrawer.jsx
@@ -31,6 +31,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { useParams } from "react-router-dom";
 import { createPostId, createPost, deleteAttachment, bulkActivateAttachments, cleanupPostAttachments } from "@/features/project/post/postSlice";
 import * as postAPI from "@/api/post";
+import CustomButton from "@/components/common/customButton/CustomButton";
 
 export default function CreatePostDrawer({ open, onClose, onSubmit }) {
   const theme = useTheme();
@@ -578,22 +579,13 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
                       accept="*"
                     />
                     <label htmlFor="file-upload">
-                      <Button 
-                        variant="outlined" 
+                      <CustomButton 
+                        kind="ghost"
                         component="span"
                         startIcon={<CloudUpload />}
-                        sx={{ 
-                          border: '2px dashed',
-                          borderColor: 'primary.main',
-                          color: 'primary.main',
-                          '&:hover': {
-                            borderColor: 'primary.dark',
-                            backgroundColor: 'primary.50'
-                          }
-                        }}
                       >
                         파일 선택
-                      </Button>
+                      </CustomButton>
                     </label>
                   </Stack>
                 </Box>
@@ -740,16 +732,16 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
                 )}
 
                 <Stack direction="row" justifyContent="flex-end" spacing={2}>
-                  <Button variant="text" onClick={handleCancel}>
+                  <CustomButton kind="text" onClick={handleCancel}>
                     취소
-                  </Button>
-                  <Button
-                    variant="contained"
+                  </CustomButton>
+                  <CustomButton
+                    kind="primary"
                     onClick={handleSubmit}
                     disabled={loading}
                   >
                     {loading ? "등록 중…" : "등록"}
-                  </Button>
+                  </CustomButton>
                 </Stack>
               </>
             )}

--- a/src/features/project/post/postSlice.js
+++ b/src/features/project/post/postSlice.js
@@ -304,6 +304,17 @@ const postSlice = createSlice({
     clearImagesError(state) {
       state.imagesError = null;
     },
+    clearAttachmentImages(state) {
+      // 기존 Object URL들 정리 (메모리 누수 방지)
+      state.attachmentImages.forEach(image => {
+        if (image.imageUrl) {
+          URL.revokeObjectURL(image.imageUrl);
+        }
+      });
+      state.attachmentImages = [];
+      state.imagesLoading = false;
+      state.imagesError = null;
+    },
   },
   extraReducers: (builder) => {
     builder
@@ -496,5 +507,5 @@ const postSlice = createSlice({
   },
 });
 
-export const { clearPostDetail, clearNewPostId, clearAttachmentError, clearImagesError } = postSlice.actions;
+export const { clearPostDetail, clearNewPostId, clearAttachmentError, clearImagesError, clearAttachmentImages } = postSlice.actions;
 export default postSlice.reducer;


### PR DESCRIPTION
# 📌 개요
게시글 첨부 기능을 이미지 전용에서 범용 파일 첨부로 확장하고, 공통 CustomButton 컴포넌트 적용으로 UI 일관성 개선

# 🛠️ 변경 사항
## 게시글 작성 화면 개선
- 이미지 전용 파일 타입 검증 로직을 범용 파일 업로드로 확장
- 위험 파일 확장자 블랙리스트 적용 (.exe, .bat, .cmd 등 차단)
- 파일 타입별 아이콘 표시 로직 추가 (PDF, DOC, ZIP 등 구분)
- 업로드 허용 파일 안내 문구 수정
## 게시글 조회 화면 UI 변경
- 첨부파일 표시 방식을 큰 이미지(300px)에서 작은 파일 리스트(40px)로 변경
- 한 줄에 하나씩 파일 정보 표시하는 컴포넌트 구현
- 파일 타입별 아이콘 및 파일명, 크기 정보 표시
- 다운로드 버튼 추가 및 강제 다운로드 기능 구현
- 이미지 파일의 경우 미리보기 기능 유지
## 버그 수정 및 최적화
- 게시글 조회 시 첨부파일 상태 초기화 문제 해결 (이전 게시글 데이터 잔존 방지)
- CustomButton 컴포넌트 적용으로 UI 일관성 확보

# ✅ 주요 체크 포인트
- [x] 파일 타입 검증 로직: 위험 파일 확장자 차단이 올바르게 작동하는지 확인
- [x] 파일 다운로드 기능: S3 presigned URL을 통한 안전한 다운로드 구현 검토
- [x] 첨부파일 상태 관리: Redux 상태 초기화가 모든 시나리오에서 정상 작동하는지 확인
- [x] UI 일관성: CustomButton 사용으로 디자인 시스템 준수 여부 확인

# 🔁 테스트 결과
## 기능 테스트
- ✅ PDF, DOC, XLS, ZIP 등 다양한 파일 타입 업로드 성공
- ✅ 위험 파일(.exe, .bat) 업로드 차단 확인
- ✅ 파일 다운로드 기능 정상 작동 (강제 다운로드)
- ✅ 이미지 파일 미리보기 기능 유지
- ✅ 게시글 A → 게시글 B 조회 시 첨부파일 상태 초기화 확인
## UI/UX 테스트
- ✅ 파일 리스트 형태로 깔끔한 표시
- ✅ 파일 타입별 구분되는 아이콘 표시
- ✅ CustomButton 적용으로 일관된 버튼 디자인
- ✅ 한 줄에 하나씩 파일 정보 표시로 가독성 향상

# 🔗 연관된 이슈
- #316 