### PR TITLE
[fix] 동일 페이지에서 알림 클릭 시 drawer가 열리지 않는 문제 수정 (#319)

### DIFF
--- a/src/features/notifications/components/NotificationsDrawer.jsx
+++ b/src/features/notifications/components/NotificationsDrawer.jsx
@@ -83,9 +83,10 @@ export default function NotificationsDrawer({ open, onClose }) {
       dispatch(markNotificationsAsRead(notif.id));
     }
     if (notif.targetType === "PROJECT_CHECK_LIST") {
-      navigate(
-        `/projects/${notif.projectId}/approvals?targetId=${notif.targetId}`
-      );
+      navigate(`/projects/${notif.projectId}/approvals`, {
+        state: { openTargetId: notif.targetId },
+      });
+
       onClose();
     }
   };

--- a/src/features/project/approval/pages/ProjectApprovalsPage.jsx
+++ b/src/features/project/approval/pages/ProjectApprovalsPage.jsx
@@ -43,20 +43,18 @@ export default function ProjectApprovalsPage() {
   }, [projectId, dispatch]);
 
   useEffect(() => {
-    const params = new URLSearchParams(location.search);
+    const openTargetId = location.state?.openTargetId;
 
-    const targetId = params.get("targetId");
-
-    if (targetId && checklistItems.length > 0) {
+    if (openTargetId && checklistItems.length > 0) {
       const target = checklistItems.find(
-        (item) => String(item.id) === String(targetId)
+        (item) => String(item.id) === String(openTargetId)
       );
       if (target) {
         setSelectedItem(target);
         setDrawerOpen(true);
       }
     }
-  }, [location.search, checklistItems]);
+  }, [location.state?.openTargetId, checklistItems]);
 
   const handleStepChange = (id, title) => {
     setSelected(title);


### PR DESCRIPTION

## 📌 개요

* 동일한 프로젝트 결재 페이지(`/approvals`)에 이미 머물러 있는 상태에서 알림을 클릭해도 drawer가 열리지 않던 문제를 해결

---

## 🛠️ 변경 사항

* 알림 클릭 시 `navigate`에 `state`를 통해 `openTargetId` 전달
* `ProjectApprovalsPage`에서 `useLocation().state`로 해당 ID를 감지하고 drawer 오픈
* 기존 쿼리 기반 접근 대신 React Router의 state 기반 방식 적용

---

## ✅ 주요 체크 포인트

* [ ] 알림 클릭 시 항상 drawer가 열리는지 (현재 페이지와 관계없이)
* [ ] 직접 주소창에 접속할 때 (`?targetId=...`) 방식과 충돌하지 않는지
* [ ] drawer가 열린 후 상태 초기화가 잘 되는지 (불필요한 재열림 방지)

---

## 🔁 테스트 결과

* `/projects/1/approvals` 페이지에 있는 상태에서 알림 클릭 시 해당 체크리스트 drawer가 정상적으로 열림
* `/projects/2/approvals` 등 다른 페이지 이동 시에도 정상 동작
* state를 활용한 이동이라 브라우저 새로고침 시에는 영향 없음 (의도된 동작)

---

## 🔗 연관된 이슈

* #319 
* #304 

---

## 📑 레퍼런스

* [[React Router - Navigate with state](https://reactrouter.com/en/main/hooks/use-navigate)](https://reactrouter.com/en/main/hooks/use-navigate)
* [[React Router - useLocation](https://reactrouter.com/en/main/hooks/use-location)](https://reactrouter.com/en/main/hooks/use-location)