### PR TITLE
[feat] 알림 미읽음 개수 조회 및 사이드바 뱃지 표시 기능 추가 (#326)

### DIFF
--- a/src/api/notification.js
+++ b/src/api/notification.js
@@ -1,22 +1,14 @@
 import api from "./api";
 
-/**
- * 알림 목록 조회 (페이지네이션 및 읽음 여부 필터 가능)
- * @param {number} page - 페이지 번호 (1부터 시작)
- * @param {boolean} [isRead] - 읽음 여부 필터 (true/false)
- * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<NotificationListSelectWebResponse>
- */
 export const getNotifications = (page, isRead) =>
   api.get("/api/notifications", {
     params: {
       page,
-      ...(isRead !== undefined && { isRead }), // 조건부 파라미터 추가
+      ...(isRead !== undefined && { isRead }),
     },
   });
 
-/**
- * 알림 읽음 처리
- * @param {object} data - NotificationReadWebRequest 형식 { ids: string[] }
- * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<NotificationReadWebResponse>
- */
 export const readNotification = (data) => api.put("/api/notifications", data);
+
+export const getUnreadNotificationCount = () =>
+  api.get("/api/notifications/unread-count");

--- a/src/features/notifications/notificationSlice.js
+++ b/src/features/notifications/notificationSlice.js
@@ -1,5 +1,9 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import { getNotifications, readNotification } from "@/api/notification";
+import {
+  getNotifications,
+  readNotification,
+  getUnreadNotificationCount,
+} from "@/api/notification";
 
 export const fetchNotifications = createAsyncThunk(
   "notifications/fetch",
@@ -37,6 +41,18 @@ export const markNotificationsAsRead = createAsyncThunk(
   }
 );
 
+export const fetchUnreadNotificationCount = createAsyncThunk(
+  "notifications/fetchUnreadCount",
+  async (_, { rejectWithValue }) => {
+    try {
+      const res = await getUnreadNotificationCount();
+      return res.data.data;
+    } catch (err) {
+      return rejectWithValue(err.response?.data || err.message);
+    }
+  }
+);
+
 const notificationSlice = createSlice({
   name: "notifications",
   initialState: {
@@ -46,6 +62,7 @@ const notificationSlice = createSlice({
     page: 1,
     hasMore: true,
     readStatus: null,
+    unreadCount: 0,
   },
   reducers: {
     clearNotifications(state) {
@@ -94,7 +111,18 @@ const notificationSlice = createSlice({
       })
 
       .addCase(refreshNotifications.fulfilled, () => {})
-      .addCase(refreshNotifications.rejected, () => {});
+      .addCase(refreshNotifications.rejected, () => {})
+      .addCase(fetchUnreadNotificationCount.pending, (state) => {
+        state.unreadCountStatus = "loading";
+      })
+      .addCase(fetchUnreadNotificationCount.fulfilled, (state, action) => {
+        state.unreadCount = action.payload;
+        state.unreadCountStatus = "success";
+      })
+      .addCase(fetchUnreadNotificationCount.rejected, (state, action) => {
+        state.unreadCountStatus = "error";
+        state.error = action.payload;
+      });
   },
 });
 

--- a/src/hooks/useNotificationPolling.js
+++ b/src/hooks/useNotificationPolling.js
@@ -1,10 +1,10 @@
 import { useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { refreshNotifications } from "@/features/notifications/notificationSlice";
+import { fetchUnreadNotificationCount } from "@/features/notifications/notificationSlice";
 
 export default function useNotificationPolling(
   enabled = true,
-  intervalMs = 18000
+  intervalMs = 180000
 ) {
   const dispatch = useDispatch();
   const isLoggedIn = useSelector((state) => !!state.auth?.user);
@@ -12,10 +12,10 @@ export default function useNotificationPolling(
   useEffect(() => {
     if (!enabled || !isLoggedIn) return;
 
-    dispatch(refreshNotifications());
+    dispatch(fetchUnreadNotificationCount());
 
     const timerId = setInterval(() => {
-      dispatch(refreshNotifications());
+      dispatch(fetchUnreadNotificationCount());
     }, intervalMs);
 
     return () => clearInterval(timerId);

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -15,10 +15,12 @@ import useNotificationPolling from "@/hooks/useNotificationPolling";
 
 export default function MainLayout() {
   const [notificationsOpen, setNotificationsOpen] = useState(false);
-
-  useNotificationPolling(!notificationsOpen);
   const isMobile = useMediaQuery("(max-width:600px)");
   const [mobileOpen, setMobileOpen] = useState(false);
+
+  const unreadCount = useSelector((state) => state?.notification.unreadCount);
+
+  useNotificationPolling(!notificationsOpen);
 
   const handleDrawerToggle = () => {
     setMobileOpen((prev) => !prev);
@@ -35,6 +37,7 @@ export default function MainLayout() {
           <MenuIcon />
         </MobileToggleButton>
       )}
+
       {isMobile ? (
         <StyledDrawer
           variant="temporary"
@@ -45,17 +48,21 @@ export default function MainLayout() {
           <Sidebar
             onClose={handleDrawerToggle}
             onNotificationsClick={handleNotificationsToggle}
+            unreadCount={unreadCount}
           />
         </StyledDrawer>
       ) : (
         <Sidebar
           onClose={() => {}}
           onNotificationsClick={handleNotificationsToggle}
+          unreadCount={unreadCount}
         />
       )}
+
       <Main>
         <Outlet />
       </Main>
+
       <NotificationsDrawer
         open={notificationsOpen}
         onClose={handleNotificationsToggle}

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -79,7 +79,10 @@ export default function Sidebar({
             <Typography variant="subtitle1">{memberName || ""}</Typography>
           </div>
           <IconButton size="small" onClick={onNotificationsClick}>
-            <Badge badgeContent={unreadCount} color="error">
+            <Badge
+              badgeContent={unreadCount > 0 ? unreadCount : null}
+              color="error"
+            >
               <NotificationsRoundedIcon
                 fontSize="small"
                 sx={{ color: "grey.400" }}


### PR DESCRIPTION
## 📌 개요

- 알림의 미읽음 개수를 백엔드에서 조회하여 Redux로 관리하고, 사이드바 알림 아이콘에 뱃지로 표시되도록 구현했습니다.
- 기존 알림 폴링 로직을 리팩터링하여 미읽음 개수만 주기적으로 조회하도록 개선했습니다.

## 🛠️ 변경 사항

- 알림 미읽음 개수 조회 API 함수 추가 (`getUnreadNotificationCount`)
- Redux Thunk (`fetchUnreadNotificationCount`) 및 리듀서 로직 구현
- 사이드바 알림 아이콘에 뱃지 표시 추가 (`<Badge>`)
- `useNotificationPolling` 내부에서 `refreshNotifications` → `fetchUnreadNotificationCount`로 변경

## ✅ 주요 체크 포인트

- [ ] 미로그인 시 폴링이 중지되는지 확인
- [ ] 알림 drawer가 열려 있는 동안에는 폴링이 중지되는지 확인
- [ ] unread count가 정상적으로 반영되고 UI에 노출되는지 확인

## 🔁 테스트 결과

- 로컬 환경에서 로그인 후 알림 미읽음 수가 3분마다 갱신되는지 확인
- 알림 drawer를 열면 폴링이 중단되고, 닫으면 재시작되는지 확인
- unread count 값에 따라 뱃지가 자연스럽게 사라졌다 나타나는지 확인

## 🔗 연관된 이슈

- #326

## 📑 레퍼런스

- 없음
