### PR TITLE
[feat] 게시글 알림 클릭 시 Drawer 자동 열기 및 URL 정리 처리 (#331)

### DIFF
--- a/src/features/notifications/components/NotificationsDrawer.jsx
+++ b/src/features/notifications/components/NotificationsDrawer.jsx
@@ -82,11 +82,21 @@ export default function NotificationsDrawer({ open, onClose }) {
     if (!notif.isRead) {
       dispatch(markNotificationsAsRead(notif.id));
     }
-    if (notif.targetType === "PROJECT_CHECK_LIST") {
-      navigate(`/projects/${notif.projectId}/approvals`, {
-        state: { openTargetId: notif.targetId },
-      });
 
+    const navigationStrategies = {
+      PROJECT_CHECK_LIST: () => {
+        navigate(`/projects/${notif.projectId}/approvals`, {
+          state: { openTargetId: notif.targetId },
+        });
+      },
+      POST: () => {
+        navigate(`/projects/${notif.projectId}/posts?postId=${notif.targetId}`);
+      },
+    };
+
+    const navigateToTarget = navigationStrategies[notif.targetType];
+    if (navigateToTarget) {
+      navigateToTarget();
       onClose();
     }
   };

--- a/src/features/project/post/pages/ProjectPostsPage.jsx
+++ b/src/features/project/post/pages/ProjectPostsPage.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { Box } from "@mui/material";
 import { useDispatch, useSelector } from "react-redux";
-import { useParams } from "react-router-dom";
+import { useParams, useSearchParams, useNavigate } from "react-router-dom";
 import SectionTable from "@/components/common/sectionTable/SectionTable";
 import PostDetailDrawer from "../components/PostDetailDrawer";
 import CreatePostDrawer from "../components/CreatePostDrawer";
@@ -23,6 +23,29 @@ export default function ProjectPostsPage() {
   const [searchKey, setSearchKey] = useState("");
   const [searchText, setSearchText] = useState("");
   const [selectedPost, setSelectedPost] = useState(null);
+
+  const navigate = useNavigate();
+
+  const [searchParams] = useSearchParams();
+  const postIdFromQuery = searchParams.get("postId");
+
+  useEffect(() => {
+    if (postIdFromQuery) {
+      dispatch(fetchPostById(postIdFromQuery)).then((res) => {
+        setSelectedPost(res.payload);
+      });
+    }
+  }, [postIdFromQuery]);
+
+  const handleDrawerClose = () => {
+    setSelectedPost(null);
+
+    searchParams.delete("postId");
+    navigate(
+      { pathname: location.pathname, search: searchParams.toString() },
+      { replace: true }
+    );
+  };
 
   useEffect(() => {
     if (projectId) dispatch(fetchProjectStages(projectId));
@@ -124,7 +147,7 @@ export default function ProjectPostsPage() {
       <PostDetailDrawer
         open={Boolean(selectedPost)}
         post={selectedPost}
-        onClose={() => setSelectedPost(null)}
+        onClose={handleDrawerClose}
       />
 
       <CreatePostDrawer


### PR DESCRIPTION
## 📌 개요

- 알림 클릭 시 게시글(Post) 관련 알림도 해당 게시글 상세 Drawer로 이동되도록 기능 확장
- 게시글 상세 Drawer가 열릴 때는 `postId` 쿼리 파라미터로 상태를 전달하고, 닫을 때는 URL에서 해당 쿼리를 제거하여 깔끔하게 처리

## 🛠️ 변경 사항

- 알림 클릭 시 `targetType === 'POST'`인 경우 해당 게시글로 이동되도록 라우팅 처리
- `postId` 쿼리 파라미터를 감지하여 해당 게시글 상세 Drawer 자동 오픈 처리
- Drawer 닫을 때 `postId` 쿼리 파라미터 제거 처리

## ✅ 주요 체크 포인트

- [ ] 알림 클릭 시 게시글 Drawer가 정상적으로 열리는지
- [ ] 이미 게시글 페이지에 있는 경우에도 Drawer가 잘 열리는지
- [ ] Drawer 닫을 때 URL에서 `postId`가 제거되는지

## 🔁 테스트 결과

- 알림 클릭 시 게시글 상세 Drawer가 자동으로 열리는 것 확인
- 페이지 새로고침 시에도 `postId`가 있을 경우 Drawer가 정상적으로 열리는지 확인
- Drawer 닫을 때 `postId`가 URL에서 제거되는 것 확인

## 🔗 연관된 이슈

- #331 

## 📑 레퍼런스

- 없음
