### PR TITLE
feat : 첨부파일 활성화 API 명세 변경 부분 적용 (#332)

### DIFF
--- a/src/api/post.js
+++ b/src/api/post.js
@@ -172,13 +172,14 @@ export function uploadFileToS3(presignedUrl, file) {
  * 게시글 첨부파일 일괄 활성화
  * POST /api/posts/attachments/active
  *
- * @param {{ postId: string; }} data
+ * @param {{ postId: string; postAttachmentIds: string[]; }} data
  * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<PostAttachmentBulkActiveResponse>
  */
 export function bulkActivateAttachments(data) {
   return api.post("/api/posts/attachments/active", {
     postId: data.postId,
-    active: true,
+    postAttachmentIds: data.postAttachmentIds,
+    active: true
   });
 }
 

--- a/src/features/project/post/components/CreatePostDrawer.jsx
+++ b/src/features/project/post/components/CreatePostDrawer.jsx
@@ -367,10 +367,12 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
       const successfulFiles = files.filter(file => file.status === 'success' && file.postAttachmentId);
       if (successfulFiles.length > 0) {
         console.log(`${successfulFiles.length}개 파일 일괄 활성화 시작...`);
+        const postAttachmentIds = successfulFiles.map(file => file.postAttachmentId);
         
         try {
           await dispatch(bulkActivateAttachments({ 
-            postId: createdPostId 
+            postId: createdPostId,
+            postAttachmentIds
           })).unwrap();
           console.log('파일 일괄 활성화 완료');
         } catch (activateError) {

--- a/src/features/project/post/postSlice.js
+++ b/src/features/project/post/postSlice.js
@@ -244,9 +244,9 @@ export const deleteAttachment = createAsyncThunk(
 // 13) 첨부파일 일괄 활성화
 export const bulkActivateAttachments = createAsyncThunk(
   "post/bulkActivateAttachments",
-  async ({ postId }, thunkAPI) => {
+  async ({ postId, postAttachmentIds }, thunkAPI) => {
     try {
-      const response = await postAPI.bulkActivateAttachments({ postId });
+      const response = await postAPI.bulkActivateAttachments({ postId, postAttachmentIds });
       return response.data.data;
     } catch (err) {
       return thunkAPI.rejectWithValue(


### PR DESCRIPTION
## 📌 개요
백엔드 API 명세 변경에 따른 첨부파일 일괄 활성화 요청/응답 형식 수정

## 🛠️ 변경 사항
첨부파일 일괄 활성화 API 요청 바디에 postAttachmentIds 필드 추가
API 함수 파라미터 타입 수정: { postId } → { postId, postAttachmentIds }
Redux async thunk 액션 파라미터 업데이트
CreatePostDrawer 컴포넌트에서 성공한 파일들의 ID 배열 생성 후 API 호출

## ✅ 주요 체크 포인트
- [x] API 요청 바디 형식: postAttachmentIds 배열이 올바르게 전송되는지 확인
- [x] 백엔드 응답 형식: data.postAttachments 배열 구조 처리 검증
- [x] 파일 업로드 성공 후 활성화 프로세스 정상 동작 확인

## 🔁 테스트 결과
API 요청/응답 확인
- ✅ 요청 바디에 postId, postAttachmentIds, active 필드 정상 전송
- ✅ 응답에서 data.postAttachments 배열 구조 정상 수신
- ✅ 파일 3개 업로드 후 일괄 활성화 성공

## 기능 테스트
- ✅ 게시글 생성 + 파일 첨부 + 일괄 활성화 전체 플로우 정상 작동

## 🔗 연관된 이슈
- #332 

## 📑 레퍼런스
변경된 API 명세
- https://github.com/Kernel360/KDEV5-MY-WORK-BE/pull/300
