### PR TITLE
[refactor] checklist 알림 클릭 시 쿼리스트링 기반 Drawer 오픈 방식으로 변경 (#335)

### DIFF
--- a/src/features/notifications/components/NotificationsDrawer.jsx
+++ b/src/features/notifications/components/NotificationsDrawer.jsx
@@ -85,9 +85,9 @@ export default function NotificationsDrawer({ open, onClose }) {
 
     const navigationStrategies = {
       PROJECT_CHECK_LIST: () => {
-        navigate(`/projects/${notif.projectId}/approvals`, {
-          state: { openTargetId: notif.targetId },
-        });
+        navigate(
+          `/projects/${notif.projectId}/approvals?checklistId=${notif.targetId}`
+        );
       },
       POST: () => {
         navigate(`/projects/${notif.projectId}/posts?postId=${notif.targetId}`);


### PR DESCRIPTION
## 📌 개요

- 알림 클릭 시 checklist 상세 Drawer가 열리지 않는 문제를 해결하기 위해 기존 `location.state` 기반 로직을 쿼리스트링 방식으로 변경
## 🛠️ 변경 사항

- checklist 알림 클릭 시 라우팅 로직을 `state` 전달 방식에서 `?checklistId=...` 쿼리 방식으로 변경
- `/approvals` 페이지에서 `checklistId` 쿼리 감지하여 Drawer 자동 오픈 처리
- Drawer 닫을 때 `checklistId` 쿼리 제거 처리 추가

## ✅ 주요 체크 포인트

- [ ] 알림 클릭 시 Drawer가 정상적으로 열리는지
- [ ] checklistId 쿼리로 이동 시 새로고침 후에도 Drawer가 열리는지
- [ ] Drawer 닫을 때 checklistId 쿼리가 정상적으로 제거되는지

## 🔁 테스트 결과

- 알림 클릭 시 `/projects/:id/approvals?checklistId=...` 형태로 이동되며 Drawer가 정상적으로 열림
- 새로고침 시에도 checklistId에 해당하는 항목이 열림
- Drawer 닫을 때 URL이 원래대로 복원됨 (`checklistId` 제거됨)

## 🔗 연관된 이슈

- #335

## 📑 레퍼런스

- [React Router - useSearchParams](https://reactrouter.com/en/main/hooks/use-search-params)
