### PR TITLE
feat: 회사 생성시 중복 사업자번호 알럿 노출 #337

### DIFF
--- a/src/features/company/pages/CompanyFormPage.jsx
+++ b/src/features/company/pages/CompanyFormPage.jsx
@@ -11,6 +11,7 @@ import { Box, Button, Stack } from "@mui/material";
 import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
 import PageHeader from "@/components/layouts/pageHeader/PageHeader";
 import CompanyForm from "../components/CompanyForm";
+import AlertMessage from "@/components/common/alertMessage/AlertMessage";
 
 export default function CompanyFormPage() {
   const { id } = useParams();
@@ -35,6 +36,8 @@ export default function CompanyFormPage() {
   });
 
   const [isSubmitted, setIsSubmitted] = useState(false);
+  const [alertOpen, setAlertOpen] = useState(false);
+  const [alertMessage, setAlertMessage] = useState("");
 
   useEffect(() => {
     const generateNewCompanyId = async () => {
@@ -98,8 +101,18 @@ export default function CompanyFormPage() {
         navigate("/companies");
       }
     } catch (err) {
+      const errorData = err?.error || err;
+      if (
+        errorData?.code === "ERROR_COMPANY06" &&
+        errorData?.message
+      ) {
+        setAlertMessage(errorData.message);
+        setAlertOpen(true);
+      } else {
+        setAlertMessage("업체 등록에 실패했습니다.");
+        setAlertOpen(true);
+      }
       console.error(err);
-      // TODO: 에러 발생 시 스낵바/토스트 표시
     }
   };
 
@@ -136,6 +149,12 @@ export default function CompanyFormPage() {
         handleChange={handleChange}
         isEdit={isEdit}
         isSubmitted={isSubmitted}
+      />
+      <AlertMessage
+        open={alertOpen}
+        onClose={() => setAlertOpen(false)}
+        message={alertMessage}
+        severity="error"
       />
     </PageWrapper>
   );


### PR DESCRIPTION
## 📌 개요

- feat: 회사 생성시 중복 사업자번호 알럿 노출
## 🛠️ 변경 사항
회사 생성시 중복 사업자번호 알럿 노출
오류코드 compnay 6 번에 대해서 전달받은 message를 그대로 노출 현재 문구 ( 사업자 번호를 가진 회사가 존재합니다.)
## ✅ 주요 체크 포인트

- [ ] 중복 사업자번호를 넣고 회사 생성 

## 🔁 테스트 결과
화면에 공통 컴포넌트 알럿 노출 ( 사업자 번호를 가진 회사가 존재합니다.)

## 🔗 연관된 이슈
#337 
