### PR TITLE
fix : 직원 검색조건에 회사타입 제거 #341

### DIFF
--- a/src/features/member/components/MemberTable.jsx
+++ b/src/features/member/components/MemberTable.jsx
@@ -9,7 +9,7 @@ import AlertMessage from "@/components/common/alertMessage/AlertMessage";
 const columns = [
   { key: "name", label: "이름", type: "avatar", searchable: true },
   { key: "email", label: "이메일", type: "text", searchable: true },
-  { key: "companyName", label: "회사", type: "text", searchable: true },
+  { key: "companyName", label: "회사", type: "text", searchable: false },
   { key: "position", label: "직책", type: "text", searchable: true },
   { key: "department", label: "부서", type: "text", searchable: true },
   { key: "phoneNumber", label: "연락처", type: "text", searchable: true },


### PR DESCRIPTION
## 📌 개요

- 직원 검색조건에 회사타입 제거 #341

## 🛠️ 변경 사항

- 초기 개발단계에서 member table 에 company 이름이 없어서 회사 타입 검색에 대한 고려를 하지않고 작성 되어있음. 
회사타입은 검색조건에 추가하지 않기로 했는데 추가되어있어서 검색기능 비활성화.

## ✅ 주요 체크 포인트

- [ ] 회사타입 노출 안되게 수정

## 🔁 테스트 결과

- 화면 테스트

## 🔗 연관된 이슈
#341 
