### PR TITLE
feat : 읽지않은 알림 디자인 변경 (#346)

### DIFF
--- a/src/features/notifications/components/NotificationContentBox.jsx
+++ b/src/features/notifications/components/NotificationContentBox.jsx
@@ -9,7 +9,7 @@ const iconComponentMap = {
   FeedRounded: FeedRoundedIcon,
 };
 
-export default function NotificationContentBox({ targetType, content }) {
+export default function NotificationContentBox({ targetType, content, isUnread = false }) {
   if (!content) return null;
 
   const IconComponent = iconComponentMap[typeIconKeyMap[targetType]];
@@ -23,28 +23,30 @@ export default function NotificationContentBox({ targetType, content }) {
         px: 1.5,
         py: 1.25,
         borderRadius: 2,
-        backgroundColor: "background.default",
+        backgroundColor: isUnread ? "#fafafa" : "background.default",
         border: "1px solid",
-        borderColor: "divider",
+        borderColor: isUnread ? "#e8e8e8" : "divider",
+        boxShadow: isUnread ? "0 1px 3px rgba(0, 0, 0, 0.04)" : "none",
       }}
     >
       {IconComponent && (
         <IconComponent
           fontSize="small"
           sx={{
-            color: "text.secondary",
+            color: isUnread ? "text.primary" : "text.secondary",
             flexShrink: 0,
           }}
         />
       )}
       <Typography
         variant="body2"
-        color="text.primary"
+        color={isUnread ? "text.primary" : "text.secondary"}
         sx={{
           fontSize: 13,
           lineHeight: 1.6,
           wordBreak: "keep-all",
           whiteSpace: "pre-wrap",
+          fontWeight: isUnread ? 500 : 400,
         }}
       >
         {content}

--- a/src/features/notifications/components/NotificationsDrawer.jsx
+++ b/src/features/notifications/components/NotificationsDrawer.jsx
@@ -173,33 +173,65 @@ export default function NotificationsDrawer({ open, onClose }) {
                     py: 2,
                     bgcolor: notif.isRead
                       ? theme.palette.background.default
-                      : theme.palette.grey[100],
-                    border: `1px solid ${theme.palette.divider}`,
+                      : "#fff",
+                    border: notif.isRead
+                      ? `1px solid ${theme.palette.divider}`
+                      : `1px solid rgba(26, 26, 26, 0.15)`,
                     transition: "all 0.2s ease",
+                    position: "relative",
+                    boxShadow: !notif.isRead 
+                      ? "0 2px 8px rgba(26, 26, 26, 0.08)"
+                      : "none",
                     "&:hover": {
-                      backgroundColor: theme.palette.grey[200],
+                      backgroundColor: notif.isRead 
+                        ? theme.palette.grey[200]
+                        : "#f8f8f8",
+                      transform: "translateY(-1px)",
+                      boxShadow: !notif.isRead 
+                        ? "0 4px 12px rgba(26, 26, 26, 0.12)"
+                        : "0 2px 4px rgba(0, 0, 0, 0.1)",
                     },
                   }}
                 >
                   <Stack spacing={1}>
-                    <Box display="flex" alignItems="flex-start" gap={1}>
+                    <Box display="flex" alignItems="flex-start" gap={1.5}>
                       {!notif.isRead && (
                         <Box
                           sx={{
-                            width: 8,
-                            height: 8,
-                            mt: "6px",
+                            width: 12,
+                            height: 12,
+                            mt: "4px",
                             borderRadius: "50%",
-                            bgcolor: "text.primary",
+                            bgcolor: "#ff6b6b",
                             flexShrink: 0,
+                            boxShadow: "0 0 0 4px rgba(255, 107, 107, 0.2)",
+                            animation: !notif.isRead ? "pulse 1.33s infinite" : "none",
+                            "@keyframes pulse": {
+                              "0%": {
+                                boxShadow: "0 0 0 0 rgba(255, 107, 107, 0.7)",
+                                transform: "scale(0.8)",
+                              },
+                              "70%": {
+                                boxShadow: "0 0 0 6px rgba(255, 107, 107, 0)",
+                                transform: "scale(1)",
+                              },
+                              "100%": {
+                                boxShadow: "0 0 0 0 rgba(255, 107, 107, 0)",
+                                transform: "scale(0.8)",
+                              },
+                            },
                           }}
                         />
                       )}
                       <Typography
                         variant="body2"
-                        fontWeight={500}
-                        color="text.primary"
-                        sx={{ wordBreak: "keep-all", lineHeight: 1.6 }}
+                        fontWeight={notif.isRead ? 400 : 600}
+                        color={notif.isRead ? "text.secondary" : "text.primary"}
+                        sx={{ 
+                          wordBreak: "keep-all", 
+                          lineHeight: 1.6,
+                          flex: 1,
+                        }}
                       >
                         {`${notif.actorName}님이 ${getTargetLabel(
                           notif.targetType
@@ -209,18 +241,33 @@ export default function NotificationsDrawer({ open, onClose }) {
                       </Typography>
                     </Box>
 
-                    <NotificationContentBox
-                      targetType={notif.targetType}
-                      content={notif.content}
-                    />
+                    <Box sx={{ pl: !notif.isRead ? 2.5 : 0 }}>
+                      <NotificationContentBox
+                        targetType={notif.targetType}
+                        content={notif.content}
+                        isUnread={!notif.isRead}
+                      />
+                    </Box>
 
-                    <Typography
-                      variant="caption"
-                      color="text.secondary"
-                      textAlign="right"
+                    <Box 
+                      sx={{ 
+                        display: "flex", 
+                        justifyContent: "space-between", 
+                        alignItems: "center",
+                        pl: !notif.isRead ? 2.5 : 0 
+                      }}
                     >
-                      {formatNotificationDate(notif.createdAt)}
-                    </Typography>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ 
+                          ml: "auto",
+                          fontWeight: !notif.isRead ? 500 : 400 
+                        }}
+                      >
+                        {formatNotificationDate(notif.createdAt)}
+                      </Typography>
+                    </Box>
                   </Stack>
                 </Paper>
               ))


### PR DESCRIPTION
## 📌 개요

- 읽지않은 알림 디자인 변경 

## 🛠️ 변경 사항
- 읽지 않은 알림 표시 점을 연빨강색(#ff6b6b)으로 변경
- 맥박 애니메이션 속도를 1.5배 빠르게 조정 (2초 → 1.33초)
- 동그라미 크기 변화 애니메이션 추가 (80% ↔ 100% 스케일링)
- 읽지 않은 알림 박스 테두리를 부드럽게 개선 (2px 진한색 → 1px 연한색)
- 순수 CSS 키프레임 애니메이션으로 맥박 효과 구현

## ✅ 주요 체크 포인트
- [x] 읽지 않은 알림의 빨간색 맥박 애니메이션이 정상적으로 동작하는지 확인


## 🔁 테스트 결과
- 읽지 않은 알림 표시: 연빨강 점이 1.33초 주기로 80%↔100% 크기 변화하며 맥박 애니메이션 정상 동작
<img width="992" alt="스크린샷 2025-07-01 오후 6 09 21" src="https://github.com/user-attachments/assets/e2db79d3-2a5c-408a-95aa-05f5cadc52b1" />


## 🔗 연관된 이슈
- #346 

