### PR TITLE
fix : post삭제 생성시 페이지 이동및 데이터 갱신 추가 #348

### DIFF
--- a/src/features/project/post/components/PostDetailDrawer.jsx
+++ b/src/features/project/post/components/PostDetailDrawer.jsx
@@ -54,7 +54,7 @@ import {
 } from "../postSlice";
 import * as postAPI from "@/api/post";
 
-export default function PostDetailDrawer({ open, post, onClose }) {
+export default function PostDetailDrawer({ open, post, onClose, onDeleteSuccess }) {
   const theme = useTheme();
   const dispatch = useDispatch();
   const reviews = useSelector((state) => state.review.items || []);
@@ -205,11 +205,15 @@ export default function PostDetailDrawer({ open, post, onClose }) {
     if (!window.confirm("정말 삭제하시겠습니까?")) return;
     try {
       await dispatch(deletePost({ postId: post.postId })).unwrap();
-      alert("삭제되었습니다.");
-      onClose();
+      window.alert("삭제되었습니다.");
+      if (onDeleteSuccess) {
+        onDeleteSuccess(); // 목록만 갱신, 전체 새로고침 X
+      } else {
+        onClose();
+      }
     } catch (err) {
       console.error(err);
-      alert("삭제 실패");
+      window.alert("삭제 실패");
     }
   };
 

--- a/src/features/project/post/pages/ProjectPostsPage.jsx
+++ b/src/features/project/post/pages/ProjectPostsPage.jsx
@@ -37,32 +37,35 @@ export default function ProjectPostsPage() {
     }
   }, [postIdFromQuery]);
 
+  useEffect(() => {
+    if (selectedPost === null) {
+      dispatch(
+        fetchPosts({
+          projectId,
+          page,
+          keyword: searchText || null,
+          keywordType: searchKey ? searchKey.toUpperCase() : null,
+          projectStepId: selectedStepId,
+          approval: null,
+        })
+      );
+      if (projectId) {
+        dispatch(fetchProjectStages(projectId));
+      }
+    }
+  }, [selectedPost, dispatch, projectId, page, searchText, searchKey, selectedStepId]);
+
   const handleDrawerClose = () => {
     setSelectedPost(null);
-
+    setTimeout(() => {
+      if (document && document.body) document.body.focus();
+    }, 0);
     searchParams.delete("postId");
     navigate(
       { pathname: location.pathname, search: searchParams.toString() },
       { replace: true }
     );
   };
-
-  useEffect(() => {
-    if (projectId) dispatch(fetchProjectStages(projectId));
-  }, [dispatch, projectId]);
-
-  useEffect(() => {
-    dispatch(
-      fetchPosts({
-        projectId,
-        page,
-        keyword: searchText || null,
-        keywordType: searchKey ? searchKey.toUpperCase() : null,
-        projectStepId: selectedStepId,
-        approval: null,
-      })
-    );
-  }, [dispatch, projectId, page, selectedStepId, searchKey, searchText]);
 
   const handleRowClick = (row) => {
     dispatch(fetchPostById(row.postId))
@@ -169,6 +172,9 @@ export default function ProjectPostsPage() {
                   approval: null,
                 })
               );
+              if (projectId) {
+                dispatch(fetchProjectStages(projectId));
+              }
             })
             .catch(console.error);
         }}


### PR DESCRIPTION
## 📌 개요

-  post삭제 생성시 페이지 이동및 데이터 갱신 추가 #348

## 🛠️ 변경 사항

- post  생성 , 삭제 시 페이지 데이터 갱신  되도록 추가.

## ✅ 주요 체크 포인트

- [ ] post 삭제 시 스탭 게시글숫자 변경확인 
- [ ] post 삭제 시 리스트에서 데이터 사라졌는지 확인.
- [ ] post 생성시 스탭에 갯수가 늘어났는지 확인.

## 🔁 테스트 결과
화면 테스트

## 🔗 연관된 이슈
#348 
