### PR TITLE
feat: 알림 메시지를 targetType과 actionType에 따라 분기 처리(#350)

### DIFF
--- a/src/features/notifications/components/NotificationsDrawer.jsx
+++ b/src/features/notifications/components/NotificationsDrawer.jsx
@@ -18,9 +18,14 @@ import {
   markNotificationsAsRead,
   clearNotifications,
 } from "@/features/notifications/notificationSlice";
-import { getActionLabel, getTargetLabel } from "@/utils/notificationLabelMap";
+import {
+  getChecklistLabel,
+  getPostLabel,
+  getTargetLabel,
+} from "@/utils/notificationLabelMap";
 import NotificationContentBox from "../components/NotificationContentBox";
 import { formatNotificationDate } from "@/utils/dateUtils";
+import { alpha } from "@mui/material/styles";
 
 export default function NotificationsDrawer({ open, onClose }) {
   const theme = useTheme();
@@ -106,8 +111,8 @@ export default function NotificationsDrawer({ open, onClose }) {
       sx={{
         position: "fixed",
         top: 0,
-        left: SIDEBAR_WIDTH,
-        width: DRAWER_WIDTH,
+        left: isMobile ? 0 : SIDEBAR_WIDTH,
+        width: isMobile ? "100vw" : DRAWER_WIDTH,
         height: "100vh",
         overflow: "hidden",
         zIndex: 201,
@@ -128,7 +133,6 @@ export default function NotificationsDrawer({ open, onClose }) {
           flexDirection: "column",
         }}
       >
-        {/* 헤더 */}
         <Box
           sx={{
             display: "flex",
@@ -139,7 +143,10 @@ export default function NotificationsDrawer({ open, onClose }) {
         >
           <Box display="flex" alignItems="center" gap={1}>
             <NotificationsIcon sx={{ fontSize: 20, color: "text.primary" }} />
-            <Typography variant="h6" fontWeight={600}>
+            <Typography
+              variant="h6"
+              fontWeight={theme.typography.fontWeightBold}
+            >
               알림
             </Typography>
           </Box>
@@ -148,7 +155,6 @@ export default function NotificationsDrawer({ open, onClose }) {
           </IconButton>
         </Box>
 
-        {/* 알림 목록 */}
         <Box
           ref={scrollBoxRef}
           sx={{ overflowY: "auto", flex: 1, px: 2, pb: 2 }}
@@ -164,7 +170,7 @@ export default function NotificationsDrawer({ open, onClose }) {
               notifications?.map((notif) => (
                 <Paper
                   key={notif.id}
-                  elevation={0}
+                  elevation={notif.isRead ? 0 : 1}
                   onClick={() => handleNotificationClick(notif)}
                   sx={{
                     cursor: "pointer",
@@ -173,23 +179,23 @@ export default function NotificationsDrawer({ open, onClose }) {
                     py: 2,
                     bgcolor: notif.isRead
                       ? theme.palette.background.default
-                      : "#fff",
-                    border: notif.isRead
-                      ? `1px solid ${theme.palette.divider}`
-                      : `1px solid rgba(26, 26, 26, 0.15)`,
+                      : "#ffffff",
+                    border: `1px solid ${
+                      notif.isRead
+                        ? theme.palette.divider
+                        : alpha(theme.palette.primary.main, 0.15)
+                    }`,
                     transition: "all 0.2s ease",
-                    position: "relative",
-                    boxShadow: !notif.isRead 
-                      ? "0 2px 8px rgba(26, 26, 26, 0.08)"
-                      : "none",
+                    boxShadow: "none",
+
                     "&:hover": {
-                      backgroundColor: notif.isRead 
-                        ? theme.palette.grey[200]
+                      backgroundColor: notif.isRead
+                        ? theme.palette.grey[100]
                         : "#f8f8f8",
                       transform: "translateY(-1px)",
-                      boxShadow: !notif.isRead 
-                        ? "0 4px 12px rgba(26, 26, 26, 0.12)"
-                        : "0 2px 4px rgba(0, 0, 0, 0.1)",
+                      boxShadow: notif.isRead
+                        ? "0 2px 4px rgba(0, 0, 0, 0.1)"
+                        : "0 4px 12px rgba(26, 26, 26, 0.12)",
                     },
                   }}
                 >
@@ -202,21 +208,33 @@ export default function NotificationsDrawer({ open, onClose }) {
                             height: 12,
                             mt: "4px",
                             borderRadius: "50%",
-                            bgcolor: "#ff6b6b",
+                            bgcolor: theme.palette.status.error.main,
                             flexShrink: 0,
-                            boxShadow: "0 0 0 4px rgba(255, 107, 107, 0.2)",
-                            animation: !notif.isRead ? "pulse 1.33s infinite" : "none",
+                            boxShadow: `0 0 0 4px ${alpha(
+                              theme.palette.status.error.main,
+                              0.2
+                            )}`,
+                            animation: "pulse 1.33s infinite",
                             "@keyframes pulse": {
                               "0%": {
-                                boxShadow: "0 0 0 0 rgba(255, 107, 107, 0.7)",
+                                boxShadow: `0 0 0 0 ${alpha(
+                                  theme.palette.status.error.main,
+                                  0.7
+                                )}`,
                                 transform: "scale(0.8)",
                               },
                               "70%": {
-                                boxShadow: "0 0 0 6px rgba(255, 107, 107, 0)",
+                                boxShadow: `0 0 0 6px ${alpha(
+                                  theme.palette.status.error.main,
+                                  0
+                                )}`,
                                 transform: "scale(1)",
                               },
                               "100%": {
-                                boxShadow: "0 0 0 0 rgba(255, 107, 107, 0)",
+                                boxShadow: `0 0 0 0 ${alpha(
+                                  theme.palette.status.error.main,
+                                  0
+                                )}`,
                                 transform: "scale(0.8)",
                               },
                             },
@@ -225,23 +243,31 @@ export default function NotificationsDrawer({ open, onClose }) {
                       )}
                       <Typography
                         variant="body2"
-                        fontWeight={notif.isRead ? 400 : 600}
+                        fontWeight={
+                          notif.isRead
+                            ? theme.typography.fontWeightRegular
+                            : theme.typography.fontWeightMedium
+                        }
                         color={notif.isRead ? "text.secondary" : "text.primary"}
-                        sx={{ 
-                          wordBreak: "keep-all", 
+                        sx={{
+                          wordBreak: "keep-all",
                           lineHeight: 1.6,
                           flex: 1,
+                          ml: !notif.isRead ? 0 : 2,
                         }}
                       >
-                        {`${notif.actorName}님이 ${getTargetLabel(
-                          notif.targetType
-                        )}에 대해 ${getActionLabel(
-                          notif.actionType
-                        )}을(를) 남겼습니다.`}
+                        {notif.targetType === "POST" &&
+                        notif.actionType !== "REVIEW"
+                          ? `${notif.actorName}님이 ${getTargetLabel(notif.targetType)}의 상태를 ${getPostLabel(
+                              notif.actionType
+                            )}로 변경하였습니다.`
+                          : `${notif.actorName}님이 ${getTargetLabel(notif.targetType)}에 대해 ${getChecklistLabel(
+                              notif.actionType
+                            )}을(를) 남겼습니다.`}
                       </Typography>
                     </Box>
 
-                    <Box sx={{ pl: !notif.isRead ? 2.5 : 0 }}>
+                    <Box sx={{ pl: !notif.isRead ? 2.5 : 3 }}>
                       <NotificationContentBox
                         targetType={notif.targetType}
                         content={notif.content}
@@ -249,23 +275,24 @@ export default function NotificationsDrawer({ open, onClose }) {
                       />
                     </Box>
 
-                    <Box 
-                      sx={{ 
-                        display: "flex", 
-                        justifyContent: "space-between", 
+                    <Box
+                      sx={{
+                        display: "flex",
+                        justifyContent: "space-between",
                         alignItems: "center",
-                        pl: !notif.isRead ? 2.5 : 0 
                       }}
                     >
                       <Typography
                         variant="caption"
                         color="text.secondary"
-                        sx={{ 
-                          ml: "auto",
-                          fontWeight: !notif.isRead ? 500 : 400 
-                        }}
+                        fontWeight={
+                          notif.isRead
+                            ? theme.typography.fontWeightRegular
+                            : theme.typography.fontWeightMedium
+                        }
+                        sx={{ ml: "auto" }}
                       >
-                        {formatNotificationDate(notif.createdAt)}
+                        {formatNotificationDate(notif.actionTime)}
                       </Typography>
                     </Box>
                   </Stack>

--- a/src/utils/notificationIconMap.js
+++ b/src/utils/notificationIconMap.js
@@ -1,5 +1,5 @@
 // utils/notificationIconMap.js
 export const typeIconKeyMap = {
   PROJECT_CHECK_LIST: "AssignmentTurnedInRounded",
-  PROJECT_POST: "FeedRounded",
+  POST: "FeedRounded",
 };

--- a/src/utils/notificationLabelMap.js
+++ b/src/utils/notificationLabelMap.js
@@ -1,4 +1,4 @@
-export const getActionLabel = (type) => {
+export const getChecklistLabel = (type) => {
   switch (type) {
     case "APPROVED":
       return "승인";
@@ -8,6 +8,19 @@ export const getActionLabel = (type) => {
       return "수정 요청";
     case "PENDING":
       return "결재 요청";
+    case "REVIEW":
+      return "댓글";
+    default:
+      return type;
+  }
+};
+
+export const getPostLabel = (type) => {
+  switch (type) {
+    case "APPROVED":
+      return "답변 완료";
+    case "PENDING":
+      return "답변 대기";
     default:
       return type;
   }
@@ -17,7 +30,7 @@ export const getTargetLabel = (type) => {
   switch (type) {
     case "PROJECT_CHECK_LIST":
       return "체크리스트";
-    case "PROJECT_POST":
+    case "POST":
       return "게시글";
     default:
       return type;


### PR DESCRIPTION
## 📌 개요

* 알림 메시지를 `targetType`과 `actionType`에 따라 조건부로 다르게 출력되도록 로직을 수정했습니다.
* 게시글(POST)의 상태 변경은 `"변경하였습니다"` 문구로, 그 외 알림은 `"남겼습니다"` 문구로 출력됩니다.

---

## 🛠️ 변경 사항

* 알림 메시지 조건 분기 로직 추가

  * `targetType === "POST"` && `actionType !== "REVIEW"` → `변경하였습니다` 문구 출력
  * 그 외는 기존 `"남겼습니다"` 문구 유지
* `getPostLabel`, `getChecklistLabel`을 메시지 종류에 따라 각각 적용

---

## ✅ 주요 체크 포인트

* [ ] `POST` 타입 알림의 메시지가 자연스럽게 출력되는지
* [ ] `REVIEW` 타입은 기존 메시지 방식이 유지되는지
* [ ] 다른 알림 타입에 영향이 없는지

---

## 🔁 테스트 결과

* 다양한 알림 mock 데이터를 기반으로 메시지 출력 확인
* `POST` 변경 알림은 `"상태를 [상태명]로 변경하였습니다"`로 출력됨
* `CHECKLIST`, `REVIEW` 등은 기존대로 `"남겼습니다"` 문구 유지됨
* 시각적으로 문제 없이 렌더링됨

---

## 🔗 연관된 이슈

* #350 

---

## 📑 레퍼런스

* 없음

