### PR TITLE
feat : company_id 로컬스토리지 저장 제거 및 업체등록 페이지 접속마다 새로 발급

### DIFF
--- a/src/features/company/pages/CompanyFormPage.jsx
+++ b/src/features/company/pages/CompanyFormPage.jsx
@@ -42,17 +42,11 @@ export default function CompanyFormPage() {
   useEffect(() => {
     const generateNewCompanyId = async () => {
       if (!isEdit) {
-        const storedId = localStorage.getItem("newCompanyId");
-        if (!storedId) {
-          try {
-            const result = await dispatch(createCompanyId()).unwrap();
-            localStorage.setItem("newCompanyId", result.data.companyId);
-            setForm((prev) => ({ ...prev, id: result.data.companyId }));
-          } catch (err) {
-            console.error("회사 ID 생성 실패:", err);
-          }
-        } else {
-          setForm((prev) => ({ ...prev, id: storedId }));
+        try {
+          const result = await dispatch(createCompanyId()).unwrap();
+          setForm((prev) => ({ ...prev, id: result.data.companyId }));
+        } catch (err) {
+          console.error("회사 ID 생성 실패:", err);
         }
       }
     };
@@ -97,7 +91,6 @@ export default function CompanyFormPage() {
         navigate(`/companies/${id}`);
       } else {
         await dispatch(createCompany(form)).unwrap();
-        localStorage.removeItem("newCompanyId");
         navigate("/companies");
       }
     } catch (err) {


### PR DESCRIPTION
## 📌 개요

- company_id 로컬스토리지 저장 제거 및 업체등록 페이지 접속마다 새로 발급

## 🛠️ 변경 사항

- company_id 로컬스토리지 저장 제거
- 업체등록 페이지 접속마다 company_id 새로 발급

## ✅ 주요 체크 포인트

## 🔁 테스트 결과

## 🔗 연관된 이슈
- #352 