### PR TITLE
[refactor] PostDetailDrawer 하위 컴포넌트 분리 리팩토링 (#356)

### DIFF
--- a/src/features/project/post/components/FilePreviewModal.jsx
+++ b/src/features/project/post/components/FilePreviewModal.jsx
@@ -1,0 +1,124 @@
+import React from "react";
+import { Modal, Box, Typography, Stack, IconButton } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+
+function formatFileSize(bytes) {
+  if (bytes === 0) return "0 Bytes";
+  const k = 1024;
+  const sizes = ["Bytes", "KB", "MB", "GB"];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + " " + sizes[i];
+}
+
+export default function FilePreviewModal({ open, attachment, onClose }) {
+  if (!attachment) return null;
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        p: { xs: 1, sm: 2 },
+      }}
+    >
+      <Box
+        sx={{
+          position: "relative",
+          width: { xs: "95vw", sm: "90vw", md: "80vw" },
+          maxHeight: { xs: "95vh", sm: "90vh" },
+          bgcolor: "background.paper",
+          borderRadius: 3,
+          boxShadow: 24,
+          overflow: "hidden",
+          display: "flex",
+          flexDirection: "column",
+        }}
+      >
+        <Box
+          sx={{
+            p: 2,
+            borderBottom: "1px solid",
+            borderColor: "divider",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            bgcolor: "rgba(0, 0, 0, 0.03)",
+            backdropFilter: "blur(10px)",
+          }}
+        >
+          <Typography variant="h6" noWrap sx={{ fontWeight: 600 }}>
+            {attachment.fileName}
+          </Typography>
+          <IconButton
+            onClick={onClose}
+            size="small"
+            sx={{
+              bgcolor: "rgba(0, 0, 0, 0.1)",
+              "&:hover": {
+                bgcolor: "rgba(0, 0, 0, 0.2)",
+              },
+            }}
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
+
+        <Box
+          sx={{
+            flex: 1,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            p: 3,
+            bgcolor: "grey.50",
+            minHeight: 0,
+            position: "relative",
+          }}
+        >
+          <img
+            src={attachment.imageUrl}
+            alt={attachment.fileName}
+            style={{
+              maxWidth: "100%",
+              maxHeight: "100%",
+              objectFit: "contain",
+              borderRadius: "8px",
+              boxShadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
+            }}
+          />
+        </Box>
+
+        <Box
+          sx={{
+            p: 2,
+            borderTop: "1px solid",
+            borderColor: "divider",
+            bgcolor: "background.paper",
+          }}
+        >
+          <Stack direction="row" spacing={3} alignItems="center">
+            <Box>
+              <Typography
+                variant="body2"
+                color="text.secondary"
+                sx={{ mb: 0.5 }}
+              >
+                <strong>크기:</strong> {formatFileSize(attachment.fileSize)}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                <strong>타입:</strong> {attachment.fileType}
+              </Typography>
+            </Box>
+            <Box sx={{ flex: 1 }} />
+            <Typography variant="caption" color="text.secondary">
+              클릭하여 닫기 또는 ESC 키 사용
+            </Typography>
+          </Stack>
+        </Box>
+      </Box>
+    </Modal>
+  );
+}

--- a/src/features/project/post/components/PostDetailDrawer.jsx
+++ b/src/features/project/post/components/PostDetailDrawer.jsx
@@ -8,14 +8,6 @@ import {
   Paper,
   Avatar,
 } from "@mui/material";
-import CloseIcon from "@mui/icons-material/Close";
-import DeleteIcon from "@mui/icons-material/Delete";
-import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
-import BusinessRoundedIcon from "@mui/icons-material/BusinessRounded";
-import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
-import CustomButton from "@/components/common/customButton/CustomButton";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import HourglassBottomIcon from "@mui/icons-material/HourglassBottom";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch, useSelector } from "react-redux";
 import CommentSection from "./CommentSection";
@@ -29,6 +21,7 @@ import {
 import * as postAPI from "@/api/post";
 import FileAttachmentViewer from "./FileAttachmentViewer";
 import FilePreviewModal from "./FilePreviewModal";
+import PostDetailTopSection from "./PostDetailTopSection";
 
 export default function PostDetailDrawer({
   open,
@@ -224,104 +217,16 @@ export default function PostDetailDrawer({
         >
           {post ? (
             <Stack spacing={4}>
-              {/* 작성자 + 상태 */}
-              <Box
-                sx={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "flex-start",
+              <PostDetailTopSection
+                post={post}
+                onDelete={handleDelete}
+                onClose={() => {
+                  dispatch(clearAttachmentImages());
+                  onClose();
                 }}
-              >
-                <Stack direction="row" spacing={2} alignItems="center">
-                  <Avatar sx={{ width: 40, height: 40 }}>
-                    {post.companyName?.[0] || "?"}
-                  </Avatar>
-
-                  <Box>
-                    {/* 이름 + 회사 한 줄에 */}
-                    <Stack
-                      direction="row"
-                      spacing={2}
-                      alignItems="center"
-                      flexWrap="wrap"
-                    >
-                      <Stack direction="row" spacing={1} alignItems="center">
-                        <AccountCircleRoundedIcon
-                          sx={{ fontSize: 16, color: "text.secondary" }}
-                        />
-                        <Typography fontWeight={600}>
-                          {post.authorName}
-                        </Typography>
-                      </Stack>
-
-                      <Stack direction="row" spacing={1} alignItems="center">
-                        <BusinessRoundedIcon
-                          sx={{ fontSize: 16, color: "text.secondary" }}
-                        />
-                        <Typography variant="body2" color="text.secondary">
-                          {post.companyName}
-                        </Typography>
-                      </Stack>
-                    </Stack>
-
-                    {/* 작성일 */}
-                    <Stack
-                      direction="row"
-                      spacing={1}
-                      alignItems="center"
-                      mt={0.5}
-                    >
-                      <AccessTimeRoundedIcon
-                        sx={{ fontSize: 16, color: "text.secondary" }}
-                      />
-                      <Typography variant="caption" color="text.secondary">
-                        {post.createdAt}
-                      </Typography>
-                    </Stack>
-                  </Box>
-                </Stack>
-
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <IconButton onClick={handleDelete}>
-                    <DeleteIcon />
-                  </IconButton>
-                  <IconButton
-                    onClick={() => {
-                      dispatch(clearAttachmentImages());
-                      onClose();
-                    }}
-                  >
-                    <CloseIcon />
-                  </IconButton>
-                </Stack>
-              </Box>
-
-              {/* 제목 + 상태 */}
-              <Box
-                sx={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                }}
-              >
-                <Typography variant="h5" fontWeight={700}>
-                  {post.title}
-                </Typography>
-                <CustomButton
-                  kind={approval === "APPROVED" ? "ghost-success" : "ghost"}
-                  size="small"
-                  onClick={handleApprovalToggle}
-                  startIcon={
-                    approval === "APPROVED" ? (
-                      <CheckCircleIcon fontSize="small" />
-                    ) : (
-                      <HourglassBottomIcon fontSize="small" />
-                    )
-                  }
-                >
-                  {stat.label}
-                </CustomButton>
-              </Box>
+                onApprovalToggle={handleApprovalToggle}
+                approval={approval}
+              />
 
               {/* 본문 */}
               <Box

--- a/src/features/project/post/components/PostDetailDrawer.jsx
+++ b/src/features/project/post/components/PostDetailDrawer.jsx
@@ -6,41 +6,16 @@ import {
   IconButton,
   Stack,
   Paper,
-  Chip,
   Avatar,
-  Grid,
-  Card,
-  CardMedia,
-  CardContent,
-  Button,
-  Modal,
-  Divider,
-  Tooltip,
-  Alert,
-  CircularProgress,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import DeleteIcon from "@mui/icons-material/Delete";
 import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
 import BusinessRoundedIcon from "@mui/icons-material/BusinessRounded";
 import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
-import AttachFileIcon from "@mui/icons-material/AttachFile";
-import DownloadIcon from "@mui/icons-material/Download";
-import ZoomInIcon from "@mui/icons-material/ZoomIn";
-import ImageIcon from "@mui/icons-material/Image";
 import CustomButton from "@/components/common/customButton/CustomButton";
-import InsertDriveFileIcon from "@mui/icons-material/InsertDriveFile";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import HourglassBottomIcon from "@mui/icons-material/HourglassBottom";
-import {
-  PictureAsPdf,
-  Description,
-  TableChart,
-  Archive,
-  Code,
-  Movie,
-  MusicNote,
-} from "@mui/icons-material";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch, useSelector } from "react-redux";
 import CommentSection from "./CommentSection";
@@ -50,10 +25,10 @@ import {
   fetchAttachmentImages,
   clearAttachmentImages,
   updatePostApproval,
-  fetchPostById,
 } from "../postSlice";
 import * as postAPI from "@/api/post";
 import FileAttachmentViewer from "./FileAttachmentViewer";
+import FilePreviewModal from "./FilePreviewModal";
 
 export default function PostDetailDrawer({
   open,
@@ -392,120 +367,11 @@ export default function PostDetailDrawer({
       </Drawer>
 
       {/* 이미지 미리보기 모달 */}
-      <Modal
+      <FilePreviewModal
         open={previewModal.open}
+        attachment={previewModal.attachment}
         onClose={handlePreviewClose}
-        sx={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          p: { xs: 1, sm: 2 },
-        }}
-      >
-        <Box
-          sx={{
-            position: "relative",
-            width: { xs: "95vw", sm: "90vw", md: "80vw" },
-            maxHeight: { xs: "95vh", sm: "90vh" },
-            bgcolor: "background.paper",
-            borderRadius: 3,
-            boxShadow: 24,
-            overflow: "hidden",
-            display: "flex",
-            flexDirection: "column",
-          }}
-        >
-          {/* 모달 헤더 */}
-          <Box
-            sx={{
-              p: 2,
-              borderBottom: "1px solid",
-              borderColor: "divider",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "space-between",
-              bgcolor: "rgba(0, 0, 0, 0.03)",
-              backdropFilter: "blur(10px)",
-            }}
-          >
-            <Typography variant="h6" noWrap sx={{ fontWeight: 600 }}>
-              {previewModal.attachment?.fileName}
-            </Typography>
-            <IconButton
-              onClick={handlePreviewClose}
-              size="small"
-              sx={{
-                bgcolor: "rgba(0, 0, 0, 0.1)",
-                "&:hover": {
-                  bgcolor: "rgba(0, 0, 0, 0.2)",
-                },
-              }}
-            >
-              <CloseIcon />
-            </IconButton>
-          </Box>
-
-          {/* 이미지 */}
-          {previewModal.attachment && (
-            <Box
-              sx={{
-                flex: 1,
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                p: 3,
-                bgcolor: "grey.50",
-                minHeight: 0,
-                position: "relative",
-              }}
-            >
-              <img
-                src={previewModal.attachment.imageUrl}
-                alt={previewModal.attachment.fileName}
-                style={{
-                  maxWidth: "100%",
-                  maxHeight: "100%",
-                  objectFit: "contain",
-                  borderRadius: "8px",
-                  boxShadow: "0 8px 32px rgba(0, 0, 0, 0.1)",
-                }}
-              />
-            </Box>
-          )}
-
-          {/* 파일 정보 */}
-          <Box
-            sx={{
-              p: 2,
-              borderTop: "1px solid",
-              borderColor: "divider",
-              bgcolor: "background.paper",
-            }}
-          >
-            <Stack direction="row" spacing={3} alignItems="center">
-              <Box>
-                <Typography
-                  variant="body2"
-                  color="text.secondary"
-                  sx={{ mb: 0.5 }}
-                >
-                  <strong>크기:</strong>{" "}
-                  {previewModal.attachment
-                    ? formatFileSize(previewModal.attachment.fileSize)
-                    : ""}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  <strong>타입:</strong> {previewModal.attachment?.fileType}
-                </Typography>
-              </Box>
-              <Box sx={{ flex: 1 }} />
-              <Typography variant="caption" color="text.secondary">
-                클릭하여 닫기 또는 ESC 키 사용
-              </Typography>
-            </Stack>
-          </Box>
-        </Box>
-      </Modal>
+      />
     </>
   );
 }

--- a/src/features/project/post/components/PostDetailTopSection.jsx
+++ b/src/features/project/post/components/PostDetailTopSection.jsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { Box, Typography, IconButton, Stack, Avatar } from "@mui/material";
+import DeleteIcon from "@mui/icons-material/Delete";
+import CloseIcon from "@mui/icons-material/Close";
+import AccountCircleRoundedIcon from "@mui/icons-material/AccountCircleRounded";
+import BusinessRoundedIcon from "@mui/icons-material/BusinessRounded";
+import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
+import CustomButton from "@/components/common/customButton/CustomButton";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import HourglassBottomIcon from "@mui/icons-material/HourglassBottom";
+
+export default function PostDetailTopSection({
+  post,
+  onDelete,
+  onClose,
+  onApprovalToggle,
+  approval,
+}) {
+  const statusMap = {
+    PENDING: { label: "답변 대기", color: "neutral" },
+    APPROVED: { label: "답변 완료", color: "success" },
+  };
+
+  const stat = statusMap[approval] || {
+    label: approval ?? "-",
+    color: "neutral",
+  };
+
+  return (
+    <>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "flex-start",
+        }}
+      >
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Avatar sx={{ width: 40, height: 40 }}>
+            {post.companyName?.[0] || "?"}
+          </Avatar>
+
+          <Box>
+            <Stack
+              direction="row"
+              spacing={2}
+              alignItems="center"
+              flexWrap="wrap"
+            >
+              <Stack direction="row" spacing={1} alignItems="center">
+                <AccountCircleRoundedIcon
+                  sx={{ fontSize: 16, color: "text.secondary" }}
+                />
+                <Typography fontWeight={600}>{post.authorName}</Typography>
+              </Stack>
+
+              <Stack direction="row" spacing={1} alignItems="center">
+                <BusinessRoundedIcon
+                  sx={{ fontSize: 16, color: "text.secondary" }}
+                />
+                <Typography variant="body2" color="text.secondary">
+                  {post.companyName}
+                </Typography>
+              </Stack>
+            </Stack>
+
+            <Stack direction="row" spacing={1} alignItems="center" mt={0.5}>
+              <AccessTimeRoundedIcon
+                sx={{ fontSize: 16, color: "text.secondary" }}
+              />
+              <Typography variant="caption" color="text.secondary">
+                {post.createdAt}
+              </Typography>
+            </Stack>
+          </Box>
+        </Stack>
+
+        <Stack direction="row" spacing={1} alignItems="center">
+          <IconButton onClick={onDelete}>
+            <DeleteIcon />
+          </IconButton>
+          <IconButton onClick={onClose}>
+            <CloseIcon />
+          </IconButton>
+        </Stack>
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <Typography variant="h5" fontWeight={700}>
+          {post.title}
+        </Typography>
+        <CustomButton
+          kind={approval === "APPROVED" ? "ghost-success" : "ghost"}
+          size="small"
+          onClick={onApprovalToggle}
+          startIcon={
+            approval === "APPROVED" ? (
+              <CheckCircleIcon fontSize="small" />
+            ) : (
+              <HourglassBottomIcon fontSize="small" />
+            )
+          }
+        >
+          {stat.label}
+        </CustomButton>
+      </Box>
+    </>
+  );
+}


### PR DESCRIPTION
## 📌 개요

- PostDetailDrawer가 너무 길고 복잡하여 파일 미리보기 및 상단 섹션을 별도 컴포넌트로 분리했습니다.

## 🛠️ 변경 사항

- FilePreviewModal 컴포넌트 분리 (이미지 미리보기 전용 모달)
- PostDetailTopSection 컴포넌트 분리 (작성자 정보, 제목, 상태 버튼 포함)

## ✅ 주요 체크 포인트

- [ ] 컴포넌트 분리에 따른 스타일/동작 변화는 없는지
- [ ] 파일 다운로드, 미리보기, 승인 버튼 기능이 정상 작동하는지

## 🔁 테스트 결과

- 게시글 상세 보기에서 기존과 동일하게 렌더링되는지 확인
- 파일 미리보기 모달 정상 열림/닫힘 확인
- 삭제 및 승인 상태 변경 버튼 정상 작동 확인

## 🔗 연관된 이슈

- `- #356`

## 📑 레퍼런스

- 없음
