### PR TITLE
[feat] 알림 Drawer에 전체/읽지 않음/읽음 보기 필터 추가(#362)

### DIFF
--- a/src/features/notifications/notificationSlice.js
+++ b/src/features/notifications/notificationSlice.js
@@ -7,9 +7,9 @@ import {
 
 export const fetchNotifications = createAsyncThunk(
   "notifications/fetch",
-  async (page, { rejectWithValue }) => {
+  async ({ page, isRead }, { rejectWithValue }) => {
     try {
-      const res = await getNotifications(page);
+      const res = await getNotifications(page, isRead);
       return res.data.data;
     } catch (err) {
       return rejectWithValue(err.response?.data || err.message);
@@ -63,6 +63,7 @@ const notificationSlice = createSlice({
     hasMore: true,
     readStatus: null,
     unreadCount: 0,
+    filter: "ALL",
   },
   reducers: {
     clearNotifications(state) {
@@ -72,7 +73,14 @@ const notificationSlice = createSlice({
       state.loading = false;
       state.error = null;
     },
+    setNotificationFilter(state, action) {
+      state.filter = action.payload;
+      state.page = 1;
+      state.hasMore = true;
+      state.notifications = [];
+    },
   },
+
   extraReducers: (builder) => {
     builder
       .addCase(fetchNotifications.pending, (state) => {


### PR DESCRIPTION
### 📌 개요

* 알림 Drawer에 필터 기능(전체 / 읽지 않음 / 읽음)을 추가하여 사용자가 알림을 더 쉽게 구분하고 관리할 수 있도록 개선했습니다.

---

### 🛠️ 변경 사항

* ToggleButtonGroup을 활용한 필터 UI 추가
* 필터 상태에 따라 `fetchNotifications` 호출 시 `isRead` 조건 분기 처리
* `filter` 변경 시 기존 알림 목록 초기화를 위한 `clearNotifications()` 호출 추가

---

### ✅ 주요 체크 포인트

* [ ] 필터 클릭 시 알림 목록이 조건에 따라 올바르게 필터링되는지
* [ ] 필터 변경 후 알림 중복 없이 정상 표시되는지
* [ ] 필터 UI 반응 및 상태 전환이 자연스러운지

---

### 🔁 테스트 결과

* 전체/읽지 않음/읽음 각각 필터 선택 시 알림이 정확히 분류되는지 확인
* 필터 전환 시 목록이 초기화되고 새로운 조건에 맞게 로딩되는지 확인
* 무한 스크롤 동작이 필터별로 정상 작동하는지 테스트

---

### 🔗 연관된 이슈

* `- #362`

---

### 📑 레퍼런스

* 없음

