### PR TITLE
[chore] CICD 대상 브랜치를 dev → main 으로 변경(#366)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy to S3 & CloudFront
 # main 브랜치에 푸시될 때마다 자동 실행
 on:
   push:
-    branches: [dev]
+    branches: [main]
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION

## 📌 개요

* Github Actions 자동 배포 트리거 기준 브랜치를 `dev`에서 `main`으로 변경했습니다.
* 배포 안정성을 높이고 브랜치 전략을 정리하기 위한 작업입니다.

## 🛠️ 변경 사항

* Github Actions 워크플로우 파일의 `on.push.branches` 값을 `dev` → `main`으로 변경

```
- branches: [dev]
+ branches: [main]
```

## ✅ 주요 체크 포인트

* [ ] 워크플로우가 main 브랜치에서 정상적으로 실행되는지
* [ ] dev 브랜치에서는 더 이상 자동 배포되지 않는지

## 🔁 테스트 결과

* main 브랜치에 푸시 후 자동 배포가 정상적으로 동작하는 것을 확인했습니다.
* dev 브랜치에서는 워크플로우가 트리거되지 않음을 확인했습니다.

## 🔗 연관된 이슈

* #366 
## 📑 레퍼런스

* 없음