### PR TITLE
[fix] 회사/프로젝트/회원 목록 스크롤 동작 개선 (#374)

### DIFF
--- a/src/features/company/pages/CompanyPage.jsx
+++ b/src/features/company/pages/CompanyPage.jsx
@@ -26,7 +26,7 @@ export default function CompanyPage() {
           title="업체"
           subtitle={`총 ${totalCount ?? 0}개 업체가 등록되어 있습니다.`}
         />
-        <Box sx={{ flex: 1, overflow: "hidden", mb: 3 }}>
+        <Box sx={{ flex: 1, overflow: "auto", mb: 3 }}>
           <CompanyTable />
         </Box>
       </Box>

--- a/src/features/member/components/MemberTable.jsx
+++ b/src/features/member/components/MemberTable.jsx
@@ -5,6 +5,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import ConfirmDialog from "@/components/common/confirmDialog/ConfirmDialog";
 import AlertMessage from "@/components/common/alertMessage/AlertMessage";
+import { Box } from "@mui/material";
 
 const columns = [
   { key: "name", label: "이름", type: "avatar", searchable: true },
@@ -75,7 +76,7 @@ export default function MemberTable() {
   }));
 
   return (
-    <>
+    <Box>
       <CustomTable
         columns={columns}
         rows={drawMember || []}
@@ -124,6 +125,6 @@ export default function MemberTable() {
         message={notiMessage}
         severity={notiType}
       />
-    </>
+    </Box>
   );
 }

--- a/src/features/member/pages/MemberPage.jsx
+++ b/src/features/member/pages/MemberPage.jsx
@@ -1,4 +1,3 @@
-// src/features/project/pages/ProjectPage.jsx
 import { useSelector, useDispatch } from "react-redux";
 import { useEffect } from "react";
 import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
@@ -6,7 +5,6 @@ import PageHeader from "@/components/layouts/pageHeader/PageHeader";
 import MemberTable from "@/features/member/components/MemberTable";
 import CustomButton from "@/components/common/customButton/CustomButton";
 import { useNavigate } from "react-router-dom";
-import { Add } from "@mui/icons-material";
 import { Box } from "@mui/material";
 
 export default function MemberPage() {
@@ -28,7 +26,7 @@ export default function MemberPage() {
           title="회원"
           subtitle={`총 ${totalCount ?? 0}명의 회원이 등록되어 있습니다.`}
         />
-        <Box sx={{ flex: 1, overflow: "hidden", mb: 3 }}>
+        <Box sx={{ flex: 1, overflow: "auto", mb: 3 }}>
           <MemberTable />
         </Box>
       </Box>


### PR DESCRIPTION
## 📌 개요

* 회사, 프로젝트, 회원 목록 등의 리스트 영역에서 스크롤이 동작하지 않던 문제를 수정하고, 전체 영역에서 일관된 스크롤 동작을 적용하였습니다.

## 🛠️ 변경 사항

* Box 스타일의 `overflow: hidden` → `overflow: auto`로 변경
* 회사/프로젝트/회원 목록 스크롤 스타일 통일

## ✅ 주요 체크 포인트

* [ ] 리스트 하단까지 정상적으로 스크롤 되는지
* [ ] 반응형 레이아웃이나 기타 컴포넌트에 영향이 없는지

## 🔁 테스트 결과

* 리스트 길이를 늘려 하단 항목까지 정상적으로 노출되는지 확인
* 다양한 브라우저 및 뷰포트에서 스크롤 동작 확인
* 기존 레이아웃 깨짐 없이 정상 작동 확인

## 🔗 연관된 이슈

* 없음

## 📑 레퍼런스

* 없음