### PR TITLE
feat: 프로젝트 매니저 할당 추가

### DIFF
--- a/src/api/projectMember.js
+++ b/src/api/projectMember.js
@@ -60,3 +60,13 @@ export function getProjectMemberList(companyId, projectId) {
     { params: { companyId, projectId } }
   );
 }
+
+/**
+ * 프로젝트 매니저 임명/해임
+ * PUT /api/project-member/manager
+ * @param {{ memberId: string, projectId: string }} data
+ * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<ProjectManagerUpdateWebResponse>
+ */
+export function updateProjectManager(data) {
+  return api.put("/api/project-member/manager", data);
+}

--- a/src/features/project/home/components/CompanyMemberList.jsx
+++ b/src/features/project/home/components/CompanyMemberList.jsx
@@ -2,14 +2,16 @@ import React from "react";
 import { Box, Typography, IconButton } from "@mui/material";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { useTheme } from "@mui/material/styles";
+import CustomButton from "@/components/common/customButton/CustomButton";
 
 /**
  * @param {{
- *   selectedEmployees: { id: string, name: string, email?: string }[],
- *   onRemove: (id: string) => void
+ *   selectedEmployees: { id: string, name: string, email?: string, isManager?: boolean, memberRole?: string }[],
+ *   onRemove: (id: string) => void,
+ *   onToggleManager?: (emp: any) => void
  * }} props
  */
-export default function CompanyMemberList({ selectedEmployees, onRemove }) {
+export default function CompanyMemberList({ selectedEmployees, onRemove, onToggleManager }) {
   const theme = useTheme();
 
   return (
@@ -40,10 +42,22 @@ export default function CompanyMemberList({ selectedEmployees, onRemove }) {
             boxSizing: "border-box",
           }}
         >
-          <Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
-            <Typography variant="body2" fontWeight={600} noWrap>
-              {emp.name}
-            </Typography>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flex: 1 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+              <Typography variant="body2" fontWeight={600} noWrap>
+                {emp.name}
+              </Typography>
+              {['DEV_ADMIN', 'CLIENT_ADMIN', 'SYSTEM_ADMIN', 'ROLE_SYSTEM_ADMIN'].includes(emp.memberRole) && onToggleManager && (
+                <CustomButton
+                  kind={emp.isManager ? 'danger' : 'ghost'}
+                  size="small"
+                  onClick={() => onToggleManager(emp)}
+                  sx={{ minWidth: 64 }}
+                >
+                  매니저
+                </CustomButton>
+              )}
+            </Box>
             {emp.email && (
               <Typography variant="caption" color="text.secondary" noWrap>
                 {emp.email}

--- a/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
+++ b/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
@@ -7,6 +7,7 @@ import dayjs from "dayjs";
 import { useParams } from "react-router-dom";
 import { updateProjectStatus } from "@/api/project";
 import { STATUS_OPTIONS, getStatusLabel } from "@/utils/statusMaps";
+import { useSelector } from "react-redux";
 
 export default function ProjectBasicInfoSectionContent({
   isEditable,
@@ -27,6 +28,12 @@ export default function ProjectBasicInfoSectionContent({
   const [statusLoading, setStatusLoading] = React.useState(false);
   const [statusError, setStatusError] = React.useState("");
   const { id: projectId } = useParams();
+  const userRole = useSelector(state => state.auth.user?.role);
+  const canEditStep = [
+    "ROLE_SYSTEM_ADMIN",
+    "ROLE_DEV_ADMIN",
+    "ROLE_CLIENT_ADMIN"
+  ].includes(userRole);
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -90,12 +97,11 @@ export default function ProjectBasicInfoSectionContent({
           )}
         </Grid>
 
-        {/* 상태 드롭다운: 수정 모드에서만 */}
-        {isEditable && (
+        {canEditStep && (
           <Grid item xs={12} sm={12}>
             <TextField
               select
-              label="프로젝트 상태 (프로젝트 관리자만 수정 가능 합니다.)"
+              label="프로젝트 상태"
               value={projectStep}
               onChange={async (e) => {
                 const newStatus = e.target.value;
@@ -111,6 +117,7 @@ export default function ProjectBasicInfoSectionContent({
                 }
               }}
               fullWidth
+              sx={{ minWidth: 100 }}
               required
               helperText={statusError || undefined}
               error={!!statusError}


### PR DESCRIPTION
## 📌 개요

- 프로젝트 매니저 할당 추가

## 🛠️ 변경 사항

- 프로젝트 매니저 할당 추가 
- 프로젝트 dev client 어드민 상태값수정 가능하게 추가

## ✅ 주요 체크 포인트

- [ ] 상태값 수정 추가 및 매니저 추가 api 적용.

## 🔁 테스트 결과

- 화면 테스트

## 🔗 연관된 이슈
#372 
