### PR TITLE
refactor: companyType 파라미터 제거로 전체 회사 목록 조회 가능하도록 수정(#376)

### DIFF
--- a/src/features/company/components/CompanyTable.jsx
+++ b/src/features/company/components/CompanyTable.jsx
@@ -55,7 +55,7 @@ export default function CompanyTable() {
   ];
 
   const loadCompany = useCallback(() => {
-    const params = { page, companyType: "DEV" };
+    const params = { page };
 
     if (searchText.trim()) {
       params.keyword = searchText.trim();

--- a/src/features/company/pages/CompanyPage.jsx
+++ b/src/features/company/pages/CompanyPage.jsx
@@ -26,7 +26,7 @@ export default function CompanyPage() {
           title="업체"
           subtitle={`총 ${totalCount ?? 0}개 업체가 등록되어 있습니다.`}
         />
-        <Box sx={{ flex: 1, overflow: "hidden", mb: 3 }}>
+        <Box sx={{ flex: 1, overflow: "auto", mb: 3 }}>
           <CompanyTable />
         </Box>
       </Box>

--- a/src/features/member/components/MemberTable.jsx
+++ b/src/features/member/components/MemberTable.jsx
@@ -5,6 +5,7 @@ import { useEffect, useState, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import ConfirmDialog from "@/components/common/confirmDialog/ConfirmDialog";
 import AlertMessage from "@/components/common/alertMessage/AlertMessage";
+import { Box } from "@mui/material";
 
 const columns = [
   { key: "name", label: "이름", type: "avatar", searchable: true },
@@ -75,7 +76,7 @@ export default function MemberTable() {
   }));
 
   return (
-    <>
+    <Box>
       <CustomTable
         columns={columns}
         rows={drawMember || []}
@@ -124,6 +125,6 @@ export default function MemberTable() {
         message={notiMessage}
         severity={notiType}
       />
-    </>
+    </Box>
   );
 }

--- a/src/features/member/pages/MemberPage.jsx
+++ b/src/features/member/pages/MemberPage.jsx
@@ -1,4 +1,3 @@
-// src/features/project/pages/ProjectPage.jsx
 import { useSelector, useDispatch } from "react-redux";
 import { useEffect } from "react";
 import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
@@ -6,7 +5,6 @@ import PageHeader from "@/components/layouts/pageHeader/PageHeader";
 import MemberTable from "@/features/member/components/MemberTable";
 import CustomButton from "@/components/common/customButton/CustomButton";
 import { useNavigate } from "react-router-dom";
-import { Add } from "@mui/icons-material";
 import { Box } from "@mui/material";
 
 export default function MemberPage() {
@@ -28,7 +26,7 @@ export default function MemberPage() {
           title="회원"
           subtitle={`총 ${totalCount ?? 0}명의 회원이 등록되어 있습니다.`}
         />
-        <Box sx={{ flex: 1, overflow: "hidden", mb: 3 }}>
+        <Box sx={{ flex: 1, overflow: "auto", mb: 3 }}>
           <MemberTable />
         </Box>
       </Box>


### PR DESCRIPTION
## 📌 개요

* `companyType` 파라미터를 제거하여 전체 회사 목록을 조건 없이 조회할 수 있도록 프론트 로직을 개선

## 🛠️ 변경 사항

* `companyType: "DEV"` 고정 파라미터 제거
* 조회 요청 시 companyType이 선택되지 않으면 전체 회사 목록이 출력되도록 요청 param 수정

## ✅ 주요 체크 포인트

* [ ] 전체 회사 조회가 정상적으로 동작하는지
* [ ] keyword 검색, 페이징 등 다른 기능과 충돌 없이 작동하는지

## 🔁 테스트 결과

* 회사 페이지에서 `companyType` 파라미터 없이 전체 회사 리스트 정상 조회 확인
* 검색어 입력, 페이징 이동 등 기능 정상 작동 확인

## 🔗 연관된 이슈

* #376 

## 📑 레퍼런스

* 없음

