### PR TITLE
[fix] 게시글 닫기 시 입력값 초기화(clear)가 동작하지 않는 버그 수정(#383)

### DIFF
--- a/src/features/project/home/pages/ProjectPage.jsx
+++ b/src/features/project/home/pages/ProjectPage.jsx
@@ -1,4 +1,3 @@
-// src/features/project/pages/ProjectPage.jsx
 import { useDispatch, useSelector } from "react-redux";
 import { useEffect, useCallback } from "react";
 import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
@@ -6,12 +5,9 @@ import PageHeader from "@/components/layouts/pageHeader/PageHeader";
 import ProjectTable from "@/features/project/home/components/ProjectTable";
 import ProjectCardList from "@/features/project/home/components/ProjectCardList";
 import { useNavigate } from "react-router-dom";
-import { Box, Stack } from "@mui/material";
+import { Box } from "@mui/material";
 import { fetchAllCompanyNames } from "@/features/company/companySlice";
-import {
-  fetchProjects,
-  deleteProject,
-} from "@/features/project/slices/projectSlice";
+import { fetchProjects } from "@/features/project/slices/projectSlice";
 
 export default function ProjectPage() {
   const navigate = useNavigate();

--- a/src/features/project/post/pages/CreatePostDrawer.jsx
+++ b/src/features/project/post/pages/CreatePostDrawer.jsx
@@ -63,6 +63,22 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [confirmCallback, setConfirmCallback] = useState(() => () => {});
 
+  const handleCancel = async () => {
+    const hasUploadedFiles = files.some(
+      (file) => file.status === "success" && file.postAttachmentId
+    );
+
+    if (hasUploadedFiles && form.id) {
+      try {
+        await dispatch(cleanupPostAttachments(form.id)).unwrap();
+      } catch (error) {}
+    }
+
+    setForm((prev) => ({ ...prev, projectStepId: "", title: "", content: "" }));
+    setFiles([]);
+    onClose();
+  };
+
   const handleSubmit = async () => {
     const { id, projectStepId, title, content } = form;
     if (!projectStepId || !title.trim() || !content.trim()) return;
@@ -136,7 +152,7 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
       <Drawer
         anchor="right"
         open={open}
-        onClose={onClose}
+        onClose={handleCancel}
         PaperProps={{
           sx: { width: { xs: "100%", sm: "50vw" }, bgcolor: "transparent" },
         }}
@@ -165,7 +181,7 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
                 <Typography variant="h3" fontWeight={600}>
                   게시글 작성
                 </Typography>
-                <IconButton onClick={onClose}>
+                <IconButton onClick={handleCancel}>
                   <CloseIcon />
                 </IconButton>
               </Box>
@@ -272,7 +288,7 @@ export default function CreatePostDrawer({ open, onClose, onSubmit }) {
                 />
 
                 <Stack direction="row" justifyContent="flex-end" spacing={2}>
-                  <CustomButton kind="ghost" onClick={onClose}>
+                  <CustomButton kind="ghost" onClick={handleCancel}>
                     취소
                   </CustomButton>
                   <CustomButton

--- a/src/hooks/usePostForm.js
+++ b/src/hooks/usePostForm.js
@@ -1,9 +1,6 @@
 import { useState, useEffect } from "react";
 import {
   updateFileItem,
-  hasUnfinishedUploads,
-  hasFailedUploads,
-  getSuccessfulPostAttachmentIds,
   getUniqueFiles,
   convertToFileItems,
 } from "@/utils/fileUploadUtils";
@@ -12,7 +9,6 @@ import { uploadFileWithPresignedUrl } from "@/utils/uploadFileWithPresignedUrl";
 import {
   createPostId,
   deleteAttachment,
-  cleanupPostAttachments,
 } from "@/features/project/post/postSlice";
 
 export default function usePostForm({ dispatch, open }) {


### PR DESCRIPTION
## 📌 개요

* 게시글 작성 Drawer를 닫아도 입력값과 업로드 상태가 초기화되지 않는 문제를 해결

## 🛠️ 변경 사항

* 

## ✅ 주요 체크 포인트

* [ ] `onClose` 시점에 모든 입력값과 첨부파일이 정상 초기화되는지
* [ ] 불필요한 상태 유지로 인한 부작용이 없는지

## 🔁 테스트 결과

* 게시글 작성 후 닫고 다시 열었을 때 텍스트, 파일, 선택값 등이 모두 초기화됨을 확인
* 파일 첨부 후 닫은 뒤 재오픈 시 업로드 목록이 유지되지 않음 확인

## 🔗 연관된 이슈

* 없음

## 📑 레퍼런스

* 없음