### PR TITLE
feat: 프로젝트 금액 방어추가 #394

### DIFF
--- a/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
+++ b/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
@@ -27,6 +27,7 @@ export default function ProjectBasicInfoSectionContent({
 }) {
   const [statusLoading, setStatusLoading] = React.useState(false);
   const [statusError, setStatusError] = React.useState("");
+  const [amountError, setAmountError] = React.useState("");
   const { id: projectId } = useParams();
   const userRole = useSelector(state => state.auth.user?.role);
   const canEditStep = [
@@ -34,6 +35,16 @@ export default function ProjectBasicInfoSectionContent({
     "ROLE_DEV_ADMIN",
     "ROLE_CLIENT_ADMIN"
   ].includes(userRole);
+
+  const handleAmountChange = (event) => {
+    const value = event.target.value;
+    if (value > 1000000) {
+      setAmountError("프로젝트 금액은 만원 단위 입니다. 100억을 넘을수 없습니다. 관리자에게 문의해주세요.");
+    } else {
+      setAmountError("");
+      setProjectAmount(value);
+    }
+  };
 
   return (
     <LocalizationProvider dateAdapter={AdapterDayjs}>
@@ -80,10 +91,12 @@ export default function ProjectBasicInfoSectionContent({
             <TextField
               label="프로젝트 금액(만원)"
               value={projectAmount}
-              onChange={(e) => setProjectAmount(e.target.value)}
+              onChange={handleAmountChange}
               fullWidth
               type="number"
               inputProps={{ min: 0 }}
+              error={!!amountError}
+              helperText={amountError}
             />
           ) : (
             <>

--- a/src/features/project/home/components/ProjectForm.jsx
+++ b/src/features/project/home/components/ProjectForm.jsx
@@ -27,6 +27,18 @@ export default function ProjectForm({
   developerCompanies = [],
   isEdit = false,
 }) {
+  const [amountError, setAmountError] = React.useState("");
+
+  const handleAmountChange = (event) => {
+    const value = event.target.value;
+    if (value > 1000000) {
+      setAmountError("프로젝트 금액은 만원 단위 입니다. 100억을 넘을수 없습니다. 관리자에게 문의해주세요.");
+    } else {
+      setAmountError("");
+      handleChange("projectAmount")({ target: { value: value } });
+    }
+  };
+
   return (
     <Box
       sx={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}
@@ -117,8 +129,10 @@ export default function ProjectForm({
               placeholder="예) 1000"
               type="number"
               value={form.projectAmount || ""}
-              onChange={handleChange("projectAmount")}
+              onChange={handleAmountChange}
               fullWidth
+              error={!!amountError}
+              helperText={amountError}
               InputProps={{
                 endAdornment: <span>만원</span>,
                 inputProps: {


### PR DESCRIPTION
## 📌 개요

- 프로젝트 금액 방어추가 

## 🛠️ 변경 사항

- 프로젝트 금액 7자리 이상 입력되지 않도록 수정
- 7자리 이상시 입력안되고  공통 알럿 나오게 설정. 
( 프로젝트 금액은 만원 단위 입니다. 100억을 넘을수 없습니다. 관리자에게 문의해주세요.)
## ✅ 주요 체크 포인트

- [ ]프로젝트 수정 생성시 100억  만원단위 7자리 넘지않는지 확인.

## 🔁 테스트 결과

- <img width="795" alt="image" src="https://github.com/user-attachments/assets/e907e9ba-51d7-458b-bb74-f2ba7137998b" />

## 🔗 연관된 이슈
#394 
