### PR TITLE
[feat] 프로젝트 금액 입력란에 '만원' 단위 표시 추가(#394)

### DIFF
--- a/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
+++ b/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { Grid, TextField, Typography, MenuItem } from "@mui/material";
+import {
+  Grid,
+  TextField,
+  Typography,
+  MenuItem,
+  InputAdornment,
+} from "@mui/material";
 import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
 import { CalendarTodayRounded } from "@mui/icons-material";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
@@ -29,17 +35,19 @@ export default function ProjectBasicInfoSectionContent({
   const [statusError, setStatusError] = React.useState("");
   const [amountError, setAmountError] = React.useState("");
   const { id: projectId } = useParams();
-  const userRole = useSelector(state => state.auth.user?.role);
+  const userRole = useSelector((state) => state.auth.user?.role);
   const canEditStep = [
     "ROLE_SYSTEM_ADMIN",
     "ROLE_DEV_ADMIN",
-    "ROLE_CLIENT_ADMIN"
+    "ROLE_CLIENT_ADMIN",
   ].includes(userRole);
 
   const handleAmountChange = (event) => {
     const value = event.target.value;
     if (value > 1000000) {
-      setAmountError("프로젝트 금액은 만원 단위 입니다. 100억을 넘을수 없습니다. 관리자에게 문의해주세요.");
+      setAmountError(
+        "프로젝트 금액은 만원 단위 입니다. 100억을 넘을수 없습니다. 관리자에게 문의해주세요."
+      );
     } else {
       setAmountError("");
       setProjectAmount(value);
@@ -89,7 +97,7 @@ export default function ProjectBasicInfoSectionContent({
         <Grid item xs={12} sm={isEditable ? 12 : 6}>
           {isEditable ? (
             <TextField
-              label="프로젝트 금액(만원)"
+              label="프로젝트 금액"
               value={projectAmount}
               onChange={handleAmountChange}
               fullWidth
@@ -97,6 +105,11 @@ export default function ProjectBasicInfoSectionContent({
               inputProps={{ min: 0 }}
               error={!!amountError}
               helperText={amountError}
+              InputProps={{
+                endAdornment: (
+                  <InputAdornment position="end">만원</InputAdornment>
+                ),
+              }}
             />
           ) : (
             <>


### PR DESCRIPTION
## 📌 개요

* 프로젝트 금액 입력란에 '만원' 단위를 표시해 사용자 편의성 향상

## 🛠️ 변경 사항

* `TextField`에 `InputAdornment`를 사용해 '만원' 단위 추가

## ✅ 주요 체크 포인트

* [ ] 단위가 잘 표시되는지 확인
* [ ] 입력 기능에는 영향 없는지 확인

## 🔁 테스트 결과

* 입력 후 오른쪽에 '만원' 단위 정상 표시됨
* 숫자 입력 및 에러 메시지도 기존과 동일하게 동작함

## 🔗 연관된 이슈

* 없음

## 📑 레퍼런스

* [[MUI InputAdornment 공식 문서](https://mui.com/material-ui/api/input-adornment/)](https://mui.com/material-ui/api/input-adornment/)