### PR TITLE
[fix] 데이터가 없을 때 페이지네이션 숨기고 안내 메시지 표시(#397)

### DIFF
--- a/src/components/common/customTable/CustomTable.jsx
+++ b/src/components/common/customTable/CustomTable.jsx
@@ -211,40 +211,66 @@ export default function CustomTable({
             </TableHead>
 
             <TableBody>
-              {rows.map((row, idx) => (
-                <TableRow
-                  key={idx}
-                  hover
-                  onClick={() => onRowClick?.(row)}
-                  sx={{ cursor: "pointer" }}
-                >
-                  {columns.map((col) => (
-                    <TableCell key={col.key}>
-                      {renderCell(col, row[col.key], row, theme, companies)}
-                    </TableCell>
-                  ))}
-                  {userRole === "ROLE_SYSTEM_ADMIN" &&
-                    !hideDeleteButton &&
-                    !row.deleted && (
-                      <TableCell key="__actions__" align="center">
-                        <CustomButton
-                          kind="ghost-danger"
-                          size="small"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onDelete?.(row);
-                          }}
-                        >
-                          삭제
-                        </CustomButton>
+              {rows.length > 0 ? (
+                rows.map((row, idx) => (
+                  <TableRow
+                    key={idx}
+                    hover
+                    onClick={() => onRowClick?.(row)}
+                    sx={{ cursor: "pointer" }}
+                  >
+                    {columns.map((col) => (
+                      <TableCell key={col.key}>
+                        {renderCell(col, row[col.key], row, theme, companies)}
                       </TableCell>
-                    )}
+                    ))}
+                    {userRole === "ROLE_SYSTEM_ADMIN" &&
+                      !hideDeleteButton &&
+                      !row.deleted && (
+                        <TableCell key="__actions__" align="center">
+                          <CustomButton
+                            kind="ghost-danger"
+                            size="small"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onDelete?.(row);
+                            }}
+                          >
+                            삭제
+                          </CustomButton>
+                        </TableCell>
+                      )}
+                  </TableRow>
+                ))
+              ) : (
+                <TableRow>
+                  <TableCell
+                    colSpan={fullColumns.length}
+                    sx={{
+                      height: 200,
+                      p: 0,
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        display: "flex",
+                        justifyContent: "center",
+                        alignItems: "center",
+                        height: "100%",
+                        width: "100%",
+                      }}
+                    >
+                      <Typography variant="body2" color="text.secondary">
+                        등록된 데이터가 없습니다.
+                      </Typography>
+                    </Box>
+                  </TableCell>
                 </TableRow>
-              ))}
+              )}
             </TableBody>
           </Table>
 
-          {pagination && (
+          {pagination && rows.length > 0 && (
             <Box p={2}>
               <Stack direction="row" justifyContent="flex-end">
                 <Pagination


### PR DESCRIPTION
## 📌 개요

* 프로젝트 목록 테이블에서 데이터가 없을 때 페이지네이션이 표시되는 문제를 해결하고, 사용자에게 안내 문구를 표시하도록 수정했습니다.

---

## 🛠️ 변경 사항

* `rows.length === 0`인 경우 `<Pagination />` 숨김 처리
* `<TableBody>` 내부에서 "등록된 데이터가 없습니다." 메시지를 `<TableRow>`와 `<TableCell>`로 안전하게 렌더링
* 메시지를 가로·세로 모두 중앙 정렬되도록 스타일 적용
* hydration 에러 방지를 위해 `<tr>`가 `<div>` 밖에 렌더링되지 않도록 구조 정비

---

## ✅ 주요 체크 포인트

* [ ] 데이터가 없는 경우 안내 메시지가 중앙 정렬로 잘 표시되는지
* [ ] 데이터가 있을 경우 기존 테이블 및 페이지네이션 기능이 정상 작동하는지
* [ ] SSR 환경에서도 hydration 에러가 발생하지 않는지

---

## 🔁 테스트 결과

* 실제 프로젝트 데이터가 없는 상태에서 "등록된 데이터가 없습니다." 메시지가 올바르게 표시됨
* 데이터가 있을 경우 페이지네이션 및 테이블 렌더링 정상 작동 확인
* DevTools에서 hydration 관련 경고 메시지 없음 확인

---

## 🔗 연관된 이슈

* #397 

---

## 📑 레퍼런스

* 없음