### PR TITLE
[refactor] 구성원 카드 UI 개선 및 매니저 임명 기능을 메뉴로 분리(#402)

### DIFF
--- a/src/features/project/home/components/CompanyMemberList.jsx
+++ b/src/features/project/home/components/CompanyMemberList.jsx
@@ -1,78 +1,190 @@
-import React from "react";
-import { Box, Typography, IconButton } from "@mui/material";
-import DeleteIcon from "@mui/icons-material/Delete";
+import React, { useState } from "react";
+import {
+  Box,
+  Typography,
+  IconButton,
+  Chip,
+  Menu,
+  MenuItem,
+} from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import CustomButton from "@/components/common/customButton/CustomButton";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import PersonAddAltRoundedIcon from "@mui/icons-material/PersonAddAltRounded";
+import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
 
-/**
- * @param {{
- *   selectedEmployees: { id: string, name: string, email?: string, isManager?: boolean, memberRole?: string }[],
- *   onRemove: (id: string) => void,
- *   onToggleManager?: (emp: any) => void
- * }} props
- */
-export default function CompanyMemberList({ selectedEmployees, onRemove, onToggleManager }) {
+const ROLE_LABEL_MAP = {
+  DEV_ADMIN: "개발 관리자",
+  CLIENT_ADMIN: "클라이언트 관리자",
+  SYSTEM_ADMIN: "시스템 관리자",
+  ROLE_SYSTEM_ADMIN: "시스템 관리자",
+  USER: "일반 사용자",
+};
+
+export default function CompanyMemberList({
+  selectedEmployees,
+  onRemove,
+  onToggleManager,
+}) {
   const theme = useTheme();
+  const [anchorEl, setAnchorEl] = useState(null);
+  const [menuTarget, setMenuTarget] = useState(null);
+
+  const handleMenuOpen = (event, emp) => {
+    setAnchorEl(event.currentTarget);
+    setMenuTarget(emp);
+  };
+
+  const handleMenuClose = () => {
+    setAnchorEl(null);
+  };
+
+  const handleMenuExited = () => {
+    setMenuTarget(null);
+  };
+
+  const handleToggleManager = () => {
+    if (onToggleManager && menuTarget) {
+      onToggleManager(menuTarget);
+    }
+    handleMenuClose();
+  };
+
+  const handleRemove = () => {
+    if (onRemove && menuTarget) {
+      onRemove(menuTarget.id);
+    }
+    handleMenuClose();
+  };
+
+  // 역할 색상 매핑
+  const getRoleChipStyle = (role) => {
+    switch (role) {
+      case "DEV_ADMIN":
+        return {
+          bgcolor: theme.palette.status.info.bg,
+          color: theme.palette.status.info.main,
+        };
+      case "CLIENT_ADMIN":
+        return {
+          bgcolor: theme.palette.status.success.bg,
+          color: theme.palette.status.success.main,
+        };
+      case "SYSTEM_ADMIN":
+      case "ROLE_SYSTEM_ADMIN":
+        return {
+          bgcolor: theme.palette.status.warning.bg,
+          color: theme.palette.status.warning.main,
+        };
+      case "USER":
+      default:
+        return {
+          bgcolor: theme.palette.status.neutral.bg,
+          color: theme.palette.status.neutral.main,
+        };
+    }
+  };
 
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexWrap: "wrap",
-        gap: 1,
-        mb: 1.5,
-      }}
-    >
-      {selectedEmployees.map((emp) => (
-        <Box
-          key={emp.id}
-          sx={{
-            minWidth: 300,
-            maxWidth: 300,
-            minHeight: 80,
-            maxHeight: 80,
-            flex: "1 0 120px",
-            border: `1px solid ${theme.palette.divider}`,
-            borderRadius: 2,
-            p: 2,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            backgroundColor: theme.palette.background.paper,
-            boxSizing: "border-box",
-          }}
-        >
-          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5, flex: 1 }}>
-            <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-              <Typography variant="body2" fontWeight={600} noWrap>
-                {emp.name}
-              </Typography>
-              {['DEV_ADMIN', 'CLIENT_ADMIN', 'SYSTEM_ADMIN', 'ROLE_SYSTEM_ADMIN'].includes(emp.memberRole) && onToggleManager && (
-                <CustomButton
-                  kind={emp.isManager ? 'danger' : 'ghost-info'}
-                  size="small"
-                  onClick={() => onToggleManager(emp)}
-                  sx={{ minWidth: 64 }}
-                >
-                  {emp.isManager ? '매니저 해임' : '매니저 임명'}
-                </CustomButton>
-              )}
-            </Box>
-            {emp.email && (
-              <Typography variant="caption" color="text.secondary" noWrap>
-                {emp.email}
-              </Typography>
-            )}
-          </Box>
-          <IconButton
-            size="small"
-            onClick={() => onRemove(emp.id)}
-            sx={{ color: theme.palette.error.main }}
+    <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 1.5 }}>
+      {selectedEmployees.map((emp) => {
+        const roleLabel = ROLE_LABEL_MAP[emp.memberRole] || emp.memberRole;
+        return (
+          <Box
+            key={emp.id}
+            sx={{
+              minWidth: 300,
+              maxWidth: 300,
+              minHeight: 80,
+              maxHeight: 100,
+              flex: "1 0 120px",
+              border: `1px solid ${theme.palette.divider}`,
+              borderRadius: 2,
+              p: 2,
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "space-between",
+              backgroundColor: theme.palette.background.paper,
+              boxSizing: "border-box",
+            }}
           >
-            <DeleteIcon fontSize="small" />
-          </IconButton>
-        </Box>
-      ))}
+            <Box
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "space-between",
+              }}
+            >
+              <Box sx={{ flex: 1, overflow: "hidden" }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                  <Typography variant="body2" fontWeight={600} noWrap>
+                    {emp.name}
+                  </Typography>
+
+                  {/* 역할 Chip */}
+                  {emp.memberRole && (
+                    <Chip
+                      label={roleLabel}
+                      size="small"
+                      variant="filled"
+                      sx={{
+                        fontSize: 11,
+                        height: 20,
+                        ...getRoleChipStyle(emp.memberRole),
+                      }}
+                    />
+                  )}
+
+                  {/* 매니저 Chip */}
+                  {emp.isManager && (
+                    <Chip
+                      label="매니저"
+                      size="small"
+                      color="primary"
+                      variant="filled"
+                      sx={{ fontSize: 12, height: 22 }}
+                    />
+                  )}
+                </Box>
+
+                {emp.email && (
+                  <Typography variant="caption" color="text.secondary" noWrap>
+                    {emp.email}
+                  </Typography>
+                )}
+              </Box>
+
+              <IconButton size="small" onClick={(e) => handleMenuOpen(e, emp)}>
+                <MoreVertIcon fontSize="small" />
+              </IconButton>
+            </Box>
+          </Box>
+        );
+      })}
+
+      <Menu
+        anchorEl={anchorEl}
+        open={Boolean(anchorEl)}
+        onClose={handleMenuClose}
+        onExited={handleMenuExited}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+      >
+        {!menuTarget?.isManager &&
+          menuTarget?.memberRole !== "USER" &&
+          onToggleManager && (
+            <MenuItem onClick={handleToggleManager}>
+              <PersonAddAltRoundedIcon fontSize="small" sx={{ mr: 1 }} />
+              매니저로 임명
+            </MenuItem>
+          )}
+        <MenuItem
+          onClick={handleRemove}
+          sx={{ color: theme.palette.error.main }}
+        >
+          <DeleteRoundedIcon fontSize="small" sx={{ mr: 1 }} />
+          삭제
+        </MenuItem>
+      </Menu>
     </Box>
   );
 }

--- a/src/features/project/home/components/CompanyMemberSelector.jsx
+++ b/src/features/project/home/components/CompanyMemberSelector.jsx
@@ -18,7 +18,6 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
-import CustomButton from "@/components/common/customButton/CustomButton";
 import CompanyMemberList from "./CompanyMemberList";
 import { updateProjectManager } from "@/api/projectMember";
 import ConfirmDialog from "@/components/common/confirmDialog/ConfirmDialog";


### PR DESCRIPTION
## 📌 개요

* 구성원 카드 UI를 정리하고, 매니저 임명 기능을 `메뉴 아이템(Menu)`으로 분리하여 UX를 개선

## 🛠️ 변경 사항

* 구성원 카드 레이아웃 정리 (Chip 위치 및 정렬 개선)
* 역할별 색상 Chip 스타일링 추가
* `매니저 임명` 기능을 context menu (`MoreVertIcon` 메뉴 버튼)로 분리
* `MenuItem`에 아이콘(`PersonAddAltRounded`, `DeleteRounded`) 추가로 직관성 향상
* 역할 및 매니저 여부에 따라 메뉴 옵션 분기 처리

## ✅ 주요 체크 포인트

* [ ] 메뉴 버튼 클릭 시 올바르게 메뉴가 표시되는지
* [ ] 매니저 임명 및 삭제 동작이 의도대로 동작하는지
* [ ] 역할/권한별 메뉴 분기 로직이 올바르게 작동하는지

## 🔁 테스트 결과

* 관리자/일반 사용자의 다양한 조합으로 역할에 따른 메뉴 노출 테스트 완료
* 매니저 임명 → 카드 UI에 "매니저" Chip 즉시 반영되는지 확인
* 구성원 삭제 → 카드가 정상적으로 제거됨을 확인

## 🔗 연관된 이슈

* #402

## 📑 레퍼런스

* 없음

필요하면 더 간단한 버전이나 영문도 제공할게요!