### PR TITLE
fix: 회사 정보 수정 버튼 추가 #404

### DIFF
--- a/src/features/company/pages/CompanyDetailPage.jsx
+++ b/src/features/company/pages/CompanyDetailPage.jsx
@@ -22,6 +22,9 @@ import {
 } from "@/features/company/companySlice";
 import { getCompanyMembersByCompanyId } from "@/api/member";
 import { useTheme } from "@mui/material/styles";
+import CustomButton from "@/components/common/customButton/CustomButton";
+import CreateRoundedIcon from "@mui/icons-material/CreateRounded";
+import { ROLES } from "@/constants/roles";
 
 export default function CompanyDetailPage() {
   const theme = useTheme();
@@ -31,6 +34,7 @@ export default function CompanyDetailPage() {
   const { current: company, loading: companyLoading } = useSelector(
     (state) => state.company
   );
+  const userRole = useSelector((state) => state.auth.user?.role);
 
   const [members, setMembers] = useState([]);
   const [totalCount, setTotalCount] = useState(0);
@@ -85,13 +89,23 @@ export default function CompanyDetailPage() {
         </Box>
       </PageWrapper>
     );
-  }
+  } 
 
   return (
     <PageWrapper>
       <PageHeader
         title={company.name}
         subtitle={company.detail || "상세 설명이 없습니다."}
+        action={
+          (userRole === ROLES.SYSTEM_ADMIN) && (
+            <CustomButton
+              startIcon={<CreateRoundedIcon />}
+              onClick={() => navigate(`/companies/${id}/edit`)}
+            >
+              정보 수정
+            </CustomButton>
+          )
+        }
       />
       <Box display="flex" flexDirection="column" flex={1} minHeight={0}>
         <Paper


### PR DESCRIPTION
## 📌 개요

- 회사 정보 수정 버튼 추가 

## 🛠️ 변경 사항

- 회사 정보 수정 버튼 추가.

## ✅ 주요 체크 포인트

- [ ] 버튼을 추가해서 수정 페이지에 접근 가능 확인.

## 🔁 테스트 결과

- 로컬화면 테스트 
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/ab3417f2-b427-47bc-af40-dc02c1276110" />
## 🔗 연관된 이슈
#404 