### PR TITLE
[feat] 프로젝트 단계 상태 관리 개선 및 UI 업데이트(#417)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-router-dom": "^7.6.0",
         "recharts": "^3.0.2",
         "sass": "^1.88.0",
+        "uuid": "^11.1.0",
         "vite-plugin-svgr": "^4.3.0"
       },
       "devDependencies": {
@@ -7223,6 +7224,19 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/victory-vendor": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react-router-dom": "^7.6.0",
     "recharts": "^3.0.2",
     "sass": "^1.88.0",
+    "uuid": "^11.1.0",
     "vite-plugin-svgr": "^4.3.0"
   },
   "devDependencies": {

--- a/src/features/project/home/components/ProjectStepManager/StepCard.jsx
+++ b/src/features/project/home/components/ProjectStepManager/StepCard.jsx
@@ -1,14 +1,21 @@
 // src/components/StepCard.jsx
 import React from "react";
 import { Card, Typography, Chip, IconButton, Box } from "@mui/material";
-import EditRoundedIcon from '@mui/icons-material/EditRounded';
+import EditRoundedIcon from "@mui/icons-material/EditRounded";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { useTheme as useMuiTheme } from "@mui/material/styles";
 
-export default function StepCard({ id, label, index, onEdit }) {
+export default function StepCard({ id, label, index, onEdit, isNew, isEdit }) {
   const theme = useMuiTheme();
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id });
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -23,21 +30,33 @@ export default function StepCard({ id, label, index, onEdit }) {
       {...listeners}
       sx={{
         ...style,
-        position: 'relative',
-        display: 'flex',
-        flexDirection: 'column',
+        position: "relative",
+        display: "flex",
+        flexDirection: "column",
         p: 2,
-        border: `1px solid ${theme.palette.divider}`,
-        boxShadow: 'none',
+        boxShadow: "none",
         minWidth: 160,
         maxWidth: 180,
-        bgcolor: isDragging ? theme.palette.background.default : theme.palette.background.paper,
         borderRadius: 2,
-        flex: '0 0 auto',
+        flex: "0 0 auto",
+        bgcolor: isDragging
+          ? theme.palette.background.default
+          : theme.palette.background.paper,
+        border: isNew
+          ? `1px dashed ${theme.palette.status.info.main}`
+          : isEdit
+            ? `1px dashed ${theme.palette.status.warning.main}`
+            : `1px solid ${theme.palette.divider}`,
       }}
     >
-      {/* 번호 표시와 편집 버튼 */}
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+      {/* 번호 + 수정 버튼 + 신규 Chip */}
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
         <Chip
           label={index}
           size="small"
@@ -47,21 +66,67 @@ export default function StepCard({ id, label, index, onEdit }) {
             fontWeight: 600,
             width: 24,
             height: 24,
-            '& .MuiChip-label': { padding: 0 },
+            "& .MuiChip-label": { padding: 0 },
           }}
         />
-        <IconButton size="small"  aria-label="단계 이름 수정"   onPointerDown={(e) => e.stopPropagation()} onClick={() => onEdit?.(id)} sx={{ p: 0 }}>
-          <EditRoundedIcon fontSize="small" />
-        </IconButton>
+        <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+          <IconButton
+            size="small"
+            aria-label="단계 이름 수정"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={() => onEdit?.(id)}
+            sx={{ p: 0 }}
+          >
+            <EditRoundedIcon fontSize="small" />
+          </IconButton>
+        </Box>
       </Box>
 
-      {/* 단계 제목 */}
-      <Typography
-        variant="body1"
-        sx={{ mt: 1, textAlign: 'left', fontWeight: 500, fontSize: { xs: 14, sm: 15 } }}
-      >
-        {label}
-      </Typography>
+      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mt: 1 }}>
+        {isEdit && !isNew && (
+          <Chip
+            label="Edited"
+            size="small"
+            sx={{
+              fontSize: "0.7rem",
+              height: 20,
+              fontWeight: 500,
+              borderRadius: 1,
+              bgcolor:
+                theme.palette.status?.warning?.bg ||
+                theme.palette.warning.light,
+              color:
+                theme.palette.status?.warning?.main ||
+                theme.palette.warning.main,
+            }}
+          />
+        )}
+
+        {isNew && (
+          <Chip
+            label="New"
+            size="small"
+            sx={{
+              fontSize: "0.7rem",
+              height: 20,
+              fontWeight: 500,
+              borderRadius: 1,
+              bgcolor: theme.palette.status.info.bg,
+              color: theme.palette.status.info.main,
+            }}
+          />
+        )}
+        <Typography
+          variant="body1"
+          sx={{
+            textAlign: "left",
+            fontWeight: 500,
+            fontSize: { xs: 14, sm: 15 },
+          }}
+        >
+          {label}
+        </Typography>
+      </Box>
     </Card>
   );
 }

--- a/src/features/project/home/hooks/useProjectDetailSections.jsx
+++ b/src/features/project/home/hooks/useProjectDetailSections.jsx
@@ -1,8 +1,6 @@
 import React from "react";
-import { Typography, Tooltip, IconButton } from "@mui/material";
 import ProjectStepManager from "../components/ProjectStepManager/ProjectStepManager";
 import ProjectBasicInfoSectionContent from "../components/ProjectBasicInfoSectionContent";
-import AddRoundedIcon from "@mui/icons-material/AddRounded";
 import CompanyMemberSectionContent from "../components/CompanyMemberSectionContent";
 
 const ROLE_SYSTEM_ADMIN = "ROLE_SYSTEM_ADMIN";
@@ -12,34 +10,18 @@ const ROLE_CLIENT_ADMIN = "ROLE_CLIENT_ADMIN";
 export default function useProjectDetailSections(
   project,
   memberRole,
-  onAddStep,
   isEditable,
-  projectName,
-  setProjectName,
-  projectDetail,
-  setProjectDetail,
-  periodStart,
-  setPeriodStart,
-  periodEnd,
-  setPeriodEnd,
-  projectAmount,
-  setProjectAmount,
-  projectStep,
-  setProjectStep,
+  values,
+  setField,
   setStepEdited,
-  setStepSaveFn
+  setStepSaveFn,
+  steps,
+  setSteps,
+  initialSteps,
+  setPendingStep
 ) {
   const hasRole = (section) =>
     !section.roles || section.roles.includes(memberRole);
-
-  const renderInfoRow = (label, value) => (
-    <>
-      <Typography variant="body2" color="text.secondary">
-        {label}
-      </Typography>
-      <Typography variant="body1">{value || "-"}</Typography>
-    </>
-  );
 
   const rawSections = [
     {
@@ -50,18 +32,18 @@ export default function useProjectDetailSections(
         <ProjectBasicInfoSectionContent
           project={project}
           isEditable={isEditable}
-          projectName={projectName}
-          setProjectName={setProjectName}
-          projectDetail={projectDetail}
-          setProjectDetail={setProjectDetail}
-          periodStart={periodStart}
-          setPeriodStart={setPeriodStart}
-          periodEnd={periodEnd}
-          setPeriodEnd={setPeriodEnd}
-          projectAmount={projectAmount}
-          setProjectAmount={setProjectAmount}
-          projectStep={projectStep}
-          setProjectStep={setProjectStep}
+          projectName={values.name}
+          setProjectName={(val) => setField("name", val)}
+          projectDetail={values.detail}
+          setProjectDetail={(val) => setField("detail", val)}
+          periodStart={values.startAt}
+          setPeriodStart={(val) => setField("startAt", val)}
+          periodEnd={values.endAt}
+          setPeriodEnd={(val) => setField("endAt", val)}
+          projectAmount={values.projectAmount}
+          setProjectAmount={(val) => setField("projectAmount", val)}
+          projectStep={values.step}
+          setProjectStep={(val) => setField("step", val)}
         />
       ),
     },
@@ -70,17 +52,14 @@ export default function useProjectDetailSections(
       roles: [ROLE_SYSTEM_ADMIN, ROLE_DEV_ADMIN],
       title: "프로젝트 단계 관리",
       tooltip: "단계를 생성·수정·삭제·조회할 수 있습니다.",
-      action: (
-        <Tooltip title="단계 추가">
-          <IconButton size="small" color="primary" onClick={onAddStep}>
-            <AddRoundedIcon />
-          </IconButton>
-        </Tooltip>
-      ),
       content: (
         <ProjectStepManager
+          steps={steps}
+          setSteps={setSteps}
+          initialSteps={initialSteps}
           onEditedChange={setStepEdited}
           onSaveChange={setStepSaveFn}
+          onAddNewPendingStep={setPendingStep}
         />
       ),
     },

--- a/src/features/project/home/hooks/useProjectForm.js
+++ b/src/features/project/home/hooks/useProjectForm.js
@@ -30,14 +30,12 @@ export default function useProjectForm(projectId) {
   const [stepSaveFn, setStepSaveFn] = useState(() => async () => {});
   const [pendingStep, setPendingStep] = useState(null);
 
-  // fetch project
   useEffect(() => {
     if (projectId) {
       dispatch(fetchProjectById(projectId));
     }
   }, [dispatch, projectId]);
 
-  // fetch steps → normalize
   useEffect(() => {
     const normalized = fetchedSteps.map((s) => ({
       ...s,
@@ -48,7 +46,6 @@ export default function useProjectForm(projectId) {
     setInitialSteps((prev) => (prev.length === 0 ? sorted : prev));
   }, [fetchedSteps]);
 
-  // set initial form values from project
   useEffect(() => {
     if (project) {
       setValues({

--- a/src/features/project/home/hooks/useProjectForm.js
+++ b/src/features/project/home/hooks/useProjectForm.js
@@ -1,0 +1,167 @@
+import { useEffect, useMemo, useState, useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import dayjs from "dayjs";
+import {
+  fetchProjectById,
+  updateProject,
+} from "@/features/project/slices/projectSlice";
+import {
+  createProjectStages,
+  updateProjectStages,
+} from "@/features/project/slices/projectStepSlice";
+
+export default function useProjectForm(projectId) {
+  const dispatch = useDispatch();
+  const { current: project, loading } = useSelector((state) => state.project);
+  const fetchedSteps = useSelector((state) => state.projectStep.items) || [];
+
+  const [values, setValues] = useState({
+    name: "",
+    detail: "",
+    startAt: "",
+    endAt: "",
+    projectAmount: "",
+    step: "CONTRACT",
+  });
+
+  const [steps, setSteps] = useState([]);
+  const [initialSteps, setInitialSteps] = useState([]);
+  const [stepEdited, setStepEdited] = useState(false);
+  const [stepSaveFn, setStepSaveFn] = useState(() => async () => {});
+  const [pendingStep, setPendingStep] = useState(null);
+
+  // fetch project
+  useEffect(() => {
+    if (projectId) {
+      dispatch(fetchProjectById(projectId));
+    }
+  }, [dispatch, projectId]);
+
+  // fetch steps → normalize
+  useEffect(() => {
+    const normalized = fetchedSteps.map((s) => ({
+      ...s,
+      orderNumber: s.orderNumber ?? s.orderNum,
+    }));
+    const sorted = normalized.sort((a, b) => a.orderNumber - b.orderNumber);
+    setSteps(sorted);
+    setInitialSteps((prev) => (prev.length === 0 ? sorted : prev));
+  }, [fetchedSteps]);
+
+  // set initial form values from project
+  useEffect(() => {
+    if (project) {
+      setValues({
+        name: project.name ?? "",
+        detail: project.detail ?? "",
+        startAt: dayjs(project.startAt).format("YYYY-MM-DD") || "",
+        endAt: dayjs(project.endAt).format("YYYY-MM-DD") || "",
+        projectAmount: project.projectAmount ?? "",
+        step: project.step || "CONTRACT",
+      });
+    }
+  }, [project]);
+
+  const setField = (field, value) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const isEdited = useMemo(() => {
+    if (!project) return false;
+
+    const fieldsChanged =
+      project.name !== values.name ||
+      project.detail !== values.detail ||
+      dayjs(project.startAt).format("YYYY-MM-DD") !== values.startAt ||
+      dayjs(project.endAt).format("YYYY-MM-DD") !== values.endAt ||
+      project.projectAmount !== values.projectAmount ||
+      project.step !== values.step;
+
+    return fieldsChanged || stepEdited || pendingStep !== null;
+  }, [project, values, stepEdited, pendingStep]);
+
+  const reset = () => {
+    if (!project) return;
+
+    setValues({
+      name: project.name ?? "",
+      detail: project.detail ?? "",
+      startAt: dayjs(project.startAt).format("YYYY-MM-DD") || "",
+      endAt: dayjs(project.endAt).format("YYYY-MM-DD") || "",
+      projectAmount: project.projectAmount ?? "",
+      step: project.step || "CONTRACT",
+    });
+
+    setSteps(initialSteps);
+    setStepEdited(false);
+    setPendingStep(null);
+  };
+
+  const save = useCallback(async () => {
+    try {
+      const payload = {
+        id: projectId,
+        name: values.name,
+        detail: values.detail,
+        ...(values.startAt && { startAt: `${values.startAt}T09:00:00` }),
+        ...(values.endAt && { endAt: `${values.endAt}T18:00:00` }),
+        projectAmount:
+          values.projectAmount === "" ? null : Number(values.projectAmount),
+        step: values.step,
+        deleted: false,
+      };
+
+      await dispatch(updateProject(payload)).unwrap();
+
+      if (stepEdited) {
+        await stepSaveFn();
+        setStepEdited(false);
+      }
+
+      if (pendingStep) {
+        const nextOrder = (fetchedSteps?.length ?? 0) + 1;
+        await dispatch(
+          createProjectStages({
+            projectId,
+            projectSteps: [
+              {
+                title: pendingStep,
+                orderNumber: nextOrder,
+              },
+            ],
+          })
+        ).unwrap();
+        setPendingStep(null);
+      }
+
+      // reload latest project info after save
+      await dispatch(fetchProjectById(projectId));
+    } catch (err) {
+      console.error("프로젝트 저장 실패:", err);
+    }
+  }, [
+    dispatch,
+    projectId,
+    values,
+    stepEdited,
+    stepSaveFn,
+    pendingStep,
+    fetchedSteps,
+  ]);
+
+  return {
+    loading,
+    project,
+    values,
+    setField,
+    isEdited,
+    reset,
+    save,
+    steps,
+    setSteps,
+    initialSteps,
+    setStepEdited,
+    setStepSaveFn,
+    setPendingStep,
+  };
+}

--- a/src/features/project/home/pages/ProjectDetailPage.jsx
+++ b/src/features/project/home/pages/ProjectDetailPage.jsx
@@ -1,163 +1,50 @@
-import React, { useEffect, useState, useMemo } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import React from "react";
+import { useParams } from "react-router-dom";
 import { Box, Paper, Stack, CircularProgress } from "@mui/material";
-import { useDispatch, useSelector } from "react-redux";
-import {
-  fetchProjectById,
-  updateProject,
-} from "@/features/project/slices/projectSlice";
-import { createProjectStages } from "@/features/project/slices/projectStepSlice";
+import { useSelector } from "react-redux";
 import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
 import PageHeader from "@/components/layouts/pageHeader/PageHeader";
 import Section from "@/components/layouts/section/Section";
-import useProjectDetailSections from "../hooks/useProjectDetailSections";
 import CustomButton from "@/components/common/customButton/CustomButton";
-import TextInputDialog from "@/components/common/textInputDialog/TextInputDialog";
-import dayjs from "dayjs";
+import useProjectForm from "../hooks/useProjectForm";
+import useProjectDetailSections from "../hooks/useProjectDetailSections";
 
 export default function ProjectDetailPage() {
   const { id } = useParams();
-  const navigate = useNavigate();
-  const dispatch = useDispatch();
-
-  const {
-    current: project,
-    loading,
-    error,
-  } = useSelector((state) => state.project);
-  const { items: projectSteps = [] } = useSelector(
-    (state) => state.projectStep
-  );
   const user = useSelector((state) => state.auth?.user);
   const isAdmin = user?.role === "ROLE_SYSTEM_ADMIN";
-  const isReady = Boolean(user && id);
 
-  const [projectName, setProjectName] = useState("");
-  const [projectDetail, setProjectDetail] = useState("");
-  const [periodStart, setPeriodStart] = useState("");
-  const [periodEnd, setPeriodEnd] = useState("");
-  const [projectAmount, setProjectAmount] = useState("");
-  const [projectStep, setProjectStep] = useState("");
+  const {
+    loading,
+    project,
+    values,
+    setField,
+    isEdited,
+    reset,
+    save,
+    setStepEdited,
+    setStepSaveFn,
+    steps,
+    setSteps,
+    initialSteps,
+    setPendingStep,
+  } = useProjectForm(id);
 
-  const [isAddStepOpen, setIsAddStepOpen] = useState(false);
-  const [newStepName, setNewStepName] = useState("");
-
-  const [stepEdited, setStepEdited] = useState(false);
-  const [stepSaveFn, setStepSaveFn] = useState(() => async () => {});
-
-  useEffect(() => {
-    if (isReady) dispatch(fetchProjectById(id));
-  }, [dispatch, id, isReady]);
-
-  useEffect(() => {
-    if (!loading && error && !project) {
-      navigate("/not-found", { replace: true });
-    }
-
-    if (project) {
-      setProjectName(project.name || "");
-      setProjectDetail(project.detail || "");
-      setPeriodStart(dayjs(project.startAt).format("YYYY-MM-DD") || "");
-      setPeriodEnd(dayjs(project.endAt).format("YYYY-MM-DD") || "");
-      setProjectAmount(project.projectAmount ?? "");
-      setProjectStep(project.step || "CONTRACT");
-    }
-  }, [loading, project, error, navigate]);
-
-  const isInfoEdited = useMemo(() => {
-    if (!project) return false;
-    return (
-      project.name !== projectName ||
-      project.detail !== projectDetail ||
-      dayjs(project.startAt).format("YYYY-MM-DD") !== periodStart ||
-      dayjs(project.endAt).format("YYYY-MM-DD") !== periodEnd ||
-      project.projectAmount !== projectAmount ||
-      project.step !== projectStep
-    );
-  }, [project, projectName, projectDetail, periodStart, periodEnd, projectAmount, projectStep]);
-
-  const isEdited = isInfoEdited || stepEdited;
-
-  const handleCancel = () => {
-    if (!project) return;
-    setProjectName(project.name);
-    setProjectDetail(project.detail);
-    setPeriodStart(dayjs(project.startAt).format("YYYY-MM-DD"));
-    setPeriodEnd(dayjs(project.endAt).format("YYYY-MM-DD"));
-    setProjectAmount(project.projectAmount ?? "");
-    setProjectStep(project.step || "CONTRACT");
-  };
-
-  const handleSave = async () => {
-    try {
-      if (isInfoEdited) {
-        const payload = {
-          id,
-          name: projectName,
-          detail: projectDetail,
-          ...(periodStart && { startAt: `${periodStart}T09:00:00` }),
-          ...(periodEnd && { endAt: `${periodEnd}T18:00:00` }),
-          projectAmount: projectAmount === "" ? null : Number(projectAmount),
-          deleted: false,
-        };
-        await dispatch(updateProject(payload)).unwrap();
-      }
-
-      if (stepEdited) {
-        await stepSaveFn();
-      }
-
-      await dispatch(fetchProjectById(id));
-    } catch (err) {
-      console.error("프로젝트 업데이트 실패:", err);
-    }
-  };
-
-  const handleAddStep = () => setIsAddStepOpen(true);
-  const handleCloseAddStep = () => {
-    setIsAddStepOpen(false);
-    setNewStepName("");
-  };
-  const handleChangeNewStep = (e) => setNewStepName(e.target.value);
-  const handleConfirmAddStep = () => {
-    const nextOrder = (projectSteps?.length ?? 0) + 1;
-    dispatch(
-      createProjectStages({
-        projectId: id,
-        projectSteps: [
-          {
-            title: newStepName,
-            orderNumber: nextOrder,
-          },
-        ],
-      })
-    ).then(() => handleCloseAddStep());
-  };
-
-  const rawSections = useProjectDetailSections(
+  const sections = useProjectDetailSections(
     project,
     user?.role,
-    handleAddStep,
     isAdmin,
-    projectName,
-    setProjectName,
-    projectDetail,
-    setProjectDetail,
-    periodStart,
-    setPeriodStart,
-    periodEnd,
-    setPeriodEnd,
-    projectAmount,
-    setProjectAmount,
-    projectStep,
-    setProjectStep,
+    values,
+    setField,
     setStepEdited,
-    setStepSaveFn
+    setStepSaveFn,
+    steps,
+    setSteps,
+    initialSteps,
+    setPendingStep
   );
 
-  const sections = Array.isArray(rawSections) ? rawSections : [];
-
-  if (!isReady || loading || !project) {
+  if (!id || loading || !project) {
     return (
       <PageWrapper>
         <Box display="flex" justifyContent="center" alignItems="center" mt={10}>
@@ -173,6 +60,7 @@ export default function ProjectDetailPage() {
         title={project?.name ?? ""}
         subtitle={project?.detail ?? ""}
       />
+
       <Box
         sx={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}
       >
@@ -214,34 +102,14 @@ export default function ProjectDetailPage() {
           spacing={2}
           sx={{ px: 3, mb: 4 }}
         >
-          <CustomButton
-            kind="ghost"
-            onClick={handleCancel}
-            disabled={!isEdited}
-          >
+          <CustomButton kind="ghost" onClick={reset} disabled={!isEdited}>
             취소
           </CustomButton>
-          <CustomButton
-            kind="primary"
-            onClick={handleSave}
-            disabled={!isEdited}
-          >
+          <CustomButton kind="primary" onClick={save} disabled={!isEdited}>
             저장
           </CustomButton>
         </Stack>
       )}
-
-      <TextInputDialog
-        open={isAddStepOpen}
-        title="단계 추가"
-        label="단계 이름"
-        value={newStepName}
-        onChange={handleChangeNewStep}
-        onClose={handleCloseAddStep}
-        onConfirm={handleConfirmAddStep}
-        cancelText="취소"
-        confirmText="추가"
-      />
     </PageWrapper>
   );
 }


### PR DESCRIPTION
## 📌 개요

* 프로젝트 단계 관리와 관련된 로직을 개선하고, 상태 관리를 `useProjectForm` 훅을 사용하여 분리
* 신규 단계와 기존 단계 처리 로직을 개선하고, 단계 제목에 상태를 표시하는 UI 변경이 포함

## 🛠️ 변경 사항

* **단계 제목에 상태 표시**:

  * 'Edited'와 'New' 상태를 각각 Chip으로 표시하여 사용자에게 명확히 구분
  * 'Edited'는 경고 색상, 'New'는 정보 색상으로 표시
* **단계 생성 및 업데이트 처리 로직 개선**:

  * 신규 단계는 `createProjectStages`를 호출하여 추가하고, 기존 단계는 `updateProjectStages`로 업데이트 처리
  * `orderedSteps` 배열에서 신규 단계와 기존 단계를 분리하여 처리
* **상태 관리 리팩토링**:

  * `ProjectDetailPage`에서 단계 상태 관리 로직을 `useProjectForm` 훅으로 분리하여 코드 재사용성 및 유지보수성 향상
* **UUID 패키지 설치**:

  * 고유한 단계 ID 생성을 위해 `uuid` 패키지 설치

## ✅ 주요 체크 포인트

* [ ] `useProjectForm` 훅이 올바르게 작동하며, 상태 관리가 분리되었는지 확인
* [ ] 'Edited'와 'New' 상태가 UI에서 정확하게 표시되는지 테스트
* [ ] 신규 단계 추가 및 기존 단계 업데이트 로직이 올바르게 동작하는지 검증
* [ ] UUID 패키지가 예상대로 고유 ID를 생성하는지 확인

## 🔁 테스트 결과

* UI에서 단계 제목 옆에 'Edited'와 'New' 상태가 정상적으로 표시됨
* 신규 단계와 기존 단계의 생성 및 업데이트 로직이 의도대로 작동함
* `useProjectForm` 훅을 통해 상태 관리가 잘 분리되었으며, 관련 기능이 정상적으로 작동

## 🔗 연관된 이슈

* `- #417

## 📑 레퍼런스

* 없음