### PR TITLE
feat: 업체 내 사원 이름 검색 및 페이징 추가 #422

### DIFF
--- a/src/api/member.js
+++ b/src/api/member.js
@@ -86,8 +86,15 @@ export function getMemberProjects(memberId) {
 /**
  * 회사별 직원 목록 조회 (GET /api/companies/{companyId}/members)
  * @param {string} companyId - 조회할 회사 UUID
+ * @param {number} [page=1] - 페이지 번호 (1 이상)
+ * @param {string} [memberName=""] - 검색어 (이름 기준)
  * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<MemberListWebResponse>
  */
-export function getCompanyMembersByCompanyId(companyId) {
-  return api.get(`/api/companies/${companyId}/members`);
+export function getCompanyMembersByCompanyId(companyId, page = 1, memberName = "") {
+  return api.get(`/api/companies/${companyId}/members`, {
+    params: {
+      page,
+      memberName: memberName || undefined,
+    },
+  });
 }

--- a/src/features/company/pages/CompanyDetailPage.jsx
+++ b/src/features/company/pages/CompanyDetailPage.jsx
@@ -25,6 +25,7 @@ import { useTheme } from "@mui/material/styles";
 import CustomButton from "@/components/common/customButton/CustomButton";
 import CreateRoundedIcon from "@mui/icons-material/CreateRounded";
 import { ROLES } from "@/constants/roles";
+import Pagination from "@mui/material/Pagination";
 
 export default function CompanyDetailPage() {
   const theme = useTheme();
@@ -37,7 +38,7 @@ export default function CompanyDetailPage() {
   const userRole = useSelector((state) => state.auth.user?.role);
 
   const [members, setMembers] = useState([]);
-  const [totalCount, setTotalCount] = useState(0);
+  const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
   const [loadingMembers, setLoadingMembers] = useState(false);
   const [searchText, setSearchText] = useState("");
@@ -49,13 +50,13 @@ export default function CompanyDetailPage() {
   useEffect(() => {
     if (!company?.companyId) return;
     setLoadingMembers(true);
-    getCompanyMembersByCompanyId(company.companyId)
+    getCompanyMembersByCompanyId(company.companyId, page, searchText)
       .then((res) => {
         setMembers(res.data.data.members);
-        setTotalCount(res.data.data.totalCount);
+        setTotal(res.data.data.total);
       })
       .finally(() => setLoadingMembers(false));
-  }, [company?.companyId]);
+  }, [company?.companyId, page, searchText]);
 
   const handleDelete = async () => {
     await dispatch(deleteCompany(id)).unwrap();
@@ -237,6 +238,14 @@ export default function CompanyDetailPage() {
                   </Stack>
                 ))}
               </Stack>
+              <Box sx={{ display: 'flex', justifyContent: 'end', mt: 2 }}>
+                <Pagination
+                  count={Math.ceil(total / 10)}
+                  page={page}
+                  onChange={(_, value) => setPage(value)}
+                  size="small"
+                />
+              </Box>
             </Box>
           </Stack>
         </Paper>


### PR DESCRIPTION
## 📌 개요

-업체 내 사원 이름 검색 및 페이징 추가 #422

## 🛠️ 변경 사항

- 업체 내 사원 이름 페이징 추가 10건씩 1페이지 
- 업체 내 사원 이름 검색 추가

## ✅ 주요 체크 포인트

- [ ] 검색 기능 확인
- [ ] 10명이 넘는 직원을 보유 했을때 페이징 확인.

## 🔁 테스트 결과
<img width="1787" alt="image" src="https://github.com/user-attachments/assets/58423213-af9c-4482-b660-001f5c356921" />
<img width="1545" alt="image" src="https://github.com/user-attachments/assets/70622565-6216-457c-90b7-d3c05a4c871f" />


## 🔗 연관된 이슈
#422 
