### PR TITLE
bug :  회사 생성페이지에서 회사 이미지 변경 시 미리보기 사라지는 문제 수정(#424)

### DIFF
--- a/src/features/company/pages/CompanyFormPage.jsx
+++ b/src/features/company/pages/CompanyFormPage.jsx
@@ -50,6 +50,7 @@ export default function CompanyFormPage() {
     handleImageSelect: originalHandleImageSelect,
     handleImageDelete: originalHandleImageDelete,
     handleImageDeleteFromServer,
+    handleImageDeleteFromServerOnly,
     handleImageUpload,
     resetImageUpload,
   } = useCompanyImageUpload();
@@ -217,13 +218,13 @@ export default function CompanyFormPage() {
 
   const performUploadWithDelete = async (file, companyId) => {
     try {
-      // 1. 기존 이미지가 있으면 먼저 삭제
+      // 1. 기존 이미지가 있으면 먼저 삭제 (미리보기 유지)
       if (form.logoImagePath) {
         console.log('=== 기존 이미지 삭제 시작 ===');
         console.log('기존 이미지 경로:', form.logoImagePath);
         console.log('회사ID:', companyId);
         
-        await handleImageDeleteFromServer(companyId);
+        await handleImageDeleteFromServerOnly(companyId);
         console.log('기존 이미지 삭제 완료');
         
         // 폼에서 기존 이미지 경로 제거

--- a/src/hooks/useCompanyImageUpload.js
+++ b/src/hooks/useCompanyImageUpload.js
@@ -86,6 +86,34 @@ export default function useCompanyImageUpload() {
     }
   };
 
+  const handleImageDeleteFromServerOnly = async (companyId) => {
+    if (!companyId) {
+      console.log('handleImageDeleteFromServerOnly: companyId 없음');
+      return;
+    }
+
+    try {
+      console.log('=== 서버에서만 이미지 삭제 시작 ===');
+      console.log('회사ID:', companyId);
+      
+      setUploadStatus("uploading"); // 삭제 중 상태 표시
+      setError(null);
+
+      await deleteCompanyImage(companyId);
+      
+      // 로컬 상태는 초기화하지 않음 (미리보기 유지)
+      setUploadStatus("idle");
+      
+      console.log('=== 서버에서만 이미지 삭제 성공 ===');
+      
+    } catch (error) {
+      console.error('서버에서 이미지 삭제 실패:', error);
+      setError('이미지 삭제에 실패했습니다.');
+      setUploadStatus("error");
+      throw error;
+    }
+  };
+
   const handleImageUpload = async (file, companyId) => {
     if (!file || !companyId) {
       console.log('handleImageUpload: 파일 또는 companyId 없음', { file: file?.name, companyId });
@@ -138,6 +166,7 @@ export default function useCompanyImageUpload() {
     handleImageSelect,
     handleImageDelete,
     handleImageDeleteFromServer,
+    handleImageDeleteFromServerOnly,
     handleImageReplace,
     handleImageUpload,
     resetImageUpload,


### PR DESCRIPTION
## 📌 개요

회사 로고 이미지 변경 시 미리보기가 사라지는 UX 문제를 해결했습니다.

## 🛠️ 변경 사항

- `useCompanyImageUpload` 훅에 `handleImageDeleteFromServerOnly` 함수 추가
- `CompanyFormPage`의 이미지 교체 로직에서 새로운 삭제 함수 사용
- 서버 이미지 삭제와 로컬 미리보기 관리 로직 분리
- 이미지 변경 시 미리보기 상태 유지되도록 개선

## ✅ 주요 체크 포인트

- [x] `handleImageDeleteFromServerOnly` 함수가 서버 삭제만 수행하고 로컬 상태를 유지하는지 확인
- [x] 이미지 교체 시 미리보기가 지속적으로 표시되는지 확인
- [x] 기존 이미지 완전 삭제 기능에는 영향이 없는지 확인
- [x] 에러 처리 로직이 적절히 동작하는지 확인

## 🔁 테스트 결과

**테스트 시나리오:**
1. ✅ 회사 생성 페이지에서 이미지 최초 업로드 → 미리보기 정상 표시
2. ✅ "이미지 변경" 버튼으로 다른 이미지 선택 → 미리보기 유지됨
3. ✅ "삭제" 버튼으로 이미지 완전 삭제 → 미리보기 정상 제거
4. ✅ 이미지 업로드 중 로딩 상태 정상 표시

**결과:** 모든 시나리오에서 정상 동작 확인

## 🔗 연관된 이슈
- #424 