### PR TITLE
fix : 프로젝트 직원 매니저 할당 버그 수정

### DIFF
--- a/src/features/project/home/components/CompanyMemberSelector.jsx
+++ b/src/features/project/home/components/CompanyMemberSelector.jsx
@@ -69,14 +69,25 @@ export default function CompanyMemberSelector({
       .finally(() => setLoading(false));
   };
 
-  const handleChange = (_e, newValue) => {
+  const handleChange = async (_e, newValue) => {
     const additions = newValue.filter(
       (nv) => !assigned.some((a) => a.memberId === nv.memberId)
     );
-    additions.forEach((emp) =>
-      dispatch(addMemberToProject({ projectId, memberId: emp.memberId }))
-    );
-    setAssigned(newValue);
+    
+    // 새로 추가된 직원들을 서버에 추가
+    for (const emp of additions) {
+      await dispatch(addMemberToProject({ projectId, memberId: emp.memberId }));
+    }
+    
+    // 직원 추가 후 상세 정보를 다시 가져와서 assigned 상태 업데이트
+    if (additions.length > 0) {
+      const action = await dispatch(fetchCompanyMembersInProject({ projectId, companyId }));
+      const members = extractMembers(action.payload);
+      setAssigned(members);
+    } else {
+      setAssigned(newValue);
+    }
+    
     setOpen(false);
   };
 

--- a/src/features/project/home/components/ProjectForm.jsx
+++ b/src/features/project/home/components/ProjectForm.jsx
@@ -18,6 +18,7 @@ import { LocalizationProvider, DatePicker } from "@mui/x-date-pickers";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import { STATUS_OPTIONS } from "@/utils/statusMaps";
+import ProjectStepManager from "../components/ProjectStepManager/ProjectStepManager";
 
 export default function ProjectForm({
   form,
@@ -25,6 +26,8 @@ export default function ProjectForm({
   clientCompanies = [],
   developerCompanies = [],
   isEdit = false,
+  steps = [],
+  setSteps = () => {},
 }) {
   const [amountError, setAmountError] = React.useState("");
 
@@ -274,6 +277,26 @@ export default function ProjectForm({
                 />
               </Grid>
             </Grid>
+          </Box>
+
+          {/* 5) 프로젝트 스탭 */}
+          <Box>
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="subtitle1" fontWeight={600}>
+                5. 프로젝트 단계 관리
+              </Typography>
+              <Tooltip title="프로젝트의 단계를 입력, 수정, 순서 변경할 수 있습니다.">
+                <InfoOutlined fontSize="small" color="action" />
+              </Tooltip>
+            </Stack>
+            <Divider sx={{ mt: 1, mb: 2 }} />
+            <ProjectStepManager
+              steps={steps}
+              setSteps={setSteps}
+              initialSteps={steps}
+              onEditedChange={() => {}}
+              onSaveChange={() => {}}
+            />
           </Box>
         </Stack>
       </Paper>


### PR DESCRIPTION
## 📌 개요

- 프로젝트 직원 매니저 할당 버그 수정

## 🛠️ 변경 사항

-프로젝트 직원 추가시 누락 필드 를 통해 매니저 할당이 가능.
-매니저 할당 될 수 없도록  필드 추가 role , manager
## ✅ 주요 체크 포인트

- [ ] 직원 삭제 후 재 할당시 매니저 설정 가능 여부 확인

## 🔁 테스트 결과
화면 테스트 정상 케이스 확인.

## 🔗 연관된 이슈
#431 
