### PR TITLE
bug : 로그 페이지 사용하지 않는 컬럼(관리 컬럼) 삭제

### DIFF
--- a/src/components/common/customTable/CustomTable.jsx
+++ b/src/components/common/customTable/CustomTable.jsx
@@ -38,6 +38,7 @@ export default function CustomTable({
   secondaryFilter = null,
   onDelete,
   hideDeleteButton = false,
+  hideActionsColumn = false,
 }) {
   const { companyListOnlyIdName: companies = [] } = useSelector(
     (state) => state.company
@@ -59,11 +60,11 @@ export default function CustomTable({
 
   const fullColumns = [
     ...columns,
-    {
+    ...(hideActionsColumn ? [] : [{
       key: "__actions__",
       label: "관리",
       type: "actions",
-    },
+    }]),
   ];
 
   return (
@@ -224,7 +225,8 @@ export default function CustomTable({
                         {renderCell(col, row[col.key], row, theme, companies)}
                       </TableCell>
                     ))}
-                    {userRole === "ROLE_SYSTEM_ADMIN" &&
+                    {!hideActionsColumn && 
+                      userRole === "ROLE_SYSTEM_ADMIN" &&
                       !hideDeleteButton &&
                       !row.deleted && (
                         <TableCell key="__actions__" align="center">

--- a/src/features/logs/components/LogsTable.jsx
+++ b/src/features/logs/components/LogsTable.jsx
@@ -213,7 +213,7 @@ const LogsTable = () => {
           options: targetTypeFilterOptions,
           onChange: handleTargetTypeFilterChange,
         }}
-        hideDeleteButton={true}
+        hideActionsColumn={true}
       />
 
       <Dialog 


### PR DESCRIPTION
## 📌 개요

- 회사 수정 페이지 이미지 업로드 기능 개선 및 로그 페이지 UI 정리 작업을 완료했습니다.
- 코드 품질 향상을 위해 console.log 제거 및 상세한 주석 추가 작업을 진행했습니다.

## 🛠️ 변경 사항

### 🖼️ 회사 수정 페이지 이미지 업로드 개선
- 이미지 선택 시 presigned URL 발급 후 S3 직접 업로드 구현
- 수정 모드에서 회사 ID를 바로 사용하여 업로드 로직 최적화
- 기존 이미지 교체 시 서버 삭제 → 새 이미지 업로드 순서로 처리
- 미리보기 기능 및 업로드 상태 표시 개선

### 📝 코드 품질 개선
- 모든 console.log 제거 (프로덕션 환경 대응)
- JSDoc 스타일 상세 주석 추가
- 함수별 목적, 매개변수, 반환값 명시
- 비즈니스 로직 처리 흐름 설명 추가

### 🗂️ 로그 페이지 UI 개선
- CustomTable 컴포넌트에 `hideActionsColumn` prop 추가
- 로그 페이지에서 불필요한 관리 컬럼 완전 제거
- 테이블 레이아웃 최적화

## ✅ 주요 체크 포인트

- [ ] **이미지 업로드 로직**: 수정 모드에서 회사 ID를 바로 사용하는 방식으로 개선된 점 확인
- [ ] **에러 처리**: 이미지 업로드 실패 시 폼 상태 초기화 로직 검토
- [ ] **공용 컴포넌트**: CustomTable의 `hideActionsColumn` prop이 기존 기능에 영향 없는지 확인
- [ ] **주석 품질**: JSDoc 스타일 주석이 코드 이해에 도움이 되는지 검토

## 🔁 테스트 결과

### 회사 수정 페이지 이미지 업로드
- ✅ 이미지 선택 시 즉시 미리보기 표시 확인
- ✅ presigned URL 발급 → S3 업로드 → 폼 상태 업데이트 흐름 정상 동작
- ✅ 기존 이미지 교체 시 서버 삭제 후 새 이미지 업로드 정상 처리
- ✅ 에러 발생 시 폼 상태 초기화 정상 동작

### 로그 페이지 테이블
- ✅ 관리 컬럼 완전 제거 확인
- ✅ 다른 페이지의 CustomTable 기능 정상 동작 확인
- ✅ 필터링 및 페이지네이션 기능 정상 동작

### 코드 품질
- ✅ 모든 console.log 제거 완료
- ✅ 브라우저 콘솔에 개발용 로그 출력 없음 확인
- ✅ JSDoc 주석이 IDE에서 정상 표시되는지 확인

## 🔗 연관된 이슈

- 관련 이슈번호가 있다면 여기에 추가해주세요.
- 예: `#426` - 회사 수정 페이지 이미지 업로드 개선

## 📑 레퍼런스

- [AWS S3 Presigned URL 공식 문서](https://docs.aws.amazon.com/AmazonS3/latest/userguide/presigned-urls.html)
- [JSDoc 공식 문서](https://jsdoc.app/)
- [Material-UI Table 컴포넌트 문서](https://mui.com/material-ui/react-table/)