### PR TITLE
[refactor] 회사 직원 관리 기능 개선 – 초기 할당 상태 추적 및 변경 감지·리셋 로직 추가 (#417)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "react-dom": "^19.1.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.6.0",
+        "react-select": "^5.10.1",
         "recharts": "^3.0.2",
         "sass": "^1.88.0",
         "uuid": "^11.1.0",
@@ -1099,6 +1100,31 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.2.tgz",
+      "integrity": "sha512-wNB5ooIKHQc+Kui96jE/n69rHFWAVoxn5CAzL1Xdd8FG03cgY3MLO+GF9U3W737fYDSgPWA6MReKhBQBop6Pcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.2.tgz",
+      "integrity": "sha512-7cfaOQuCS27HD7DX+6ib2OrnW+b4ZBwDNnCcT0uTyidcmyWb03FnQqJybDBoCnpdxwBSfA94UAYlRCt7mV+TbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.2",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
+      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -5642,6 +5668,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/memoize-one": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
+      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -6282,6 +6314,27 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-select": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-5.10.1.tgz",
+      "integrity": "sha512-roPEZUL4aRZDx6DcsD+ZNreVl+fM8VsKn0Wtex1v4IazH60ILp5xhdlp464IsEAlJdXeD+BhDAFsBVMfvLQueA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.0",
+        "@emotion/cache": "^11.4.0",
+        "@emotion/react": "^11.8.1",
+        "@floating-ui/dom": "^1.0.1",
+        "@types/react-transition-group": "^4.4.0",
+        "memoize-one": "^6.0.0",
+        "prop-types": "^15.6.0",
+        "react-transition-group": "^4.3.0",
+        "use-isomorphic-layout-effect": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/react-transition-group": {
@@ -7215,6 +7268,20 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-isomorphic-layout-effect": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.2.1.tgz",
+      "integrity": "sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-dom": "^19.1.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.6.0",
+    "react-select": "^5.10.1",
     "recharts": "^3.0.2",
     "sass": "^1.88.0",
     "uuid": "^11.1.0",

--- a/src/features/project/home/components/CompanyMemberList.jsx
+++ b/src/features/project/home/components/CompanyMemberList.jsx
@@ -38,10 +38,6 @@ export default function CompanyMemberList({
     setAnchorEl(null);
   };
 
-  const handleMenuExited = () => {
-    setMenuTarget(null);
-  };
-
   const handleToggleManager = () => {
     if (onToggleManager && menuTarget) {
       onToggleManager(menuTarget);
@@ -90,7 +86,7 @@ export default function CompanyMemberList({
         const roleLabel = ROLE_LABEL_MAP[emp.memberRole] || emp.memberRole;
         return (
           <Box
-            key={emp.id}
+            key={`${emp.id}-${emp.memberRole}`}
             sx={{
               minWidth: 300,
               maxWidth: 300,
@@ -152,6 +148,40 @@ export default function CompanyMemberList({
                       }}
                     />
                   )}
+
+                  {/* 새로운 직원 표시 */}
+                  {emp.isNew && (
+                    <Chip
+                      label="새로운 직원"
+                      size="small"
+                      variant="filled"
+                      sx={{
+                        fontSize: 12,
+                        height: 22,
+                        bgcolor: theme.palette.status.info.bg,
+                        color: theme.palette.status.info.main,
+                        borderRadius: 1,
+                        fontWeight: 500,
+                      }}
+                    />
+                  )}
+
+                  {/* 삭제된 직원 표시 */}
+                  {emp.isDeleted && (
+                    <Chip
+                      label="삭제됨"
+                      size="small"
+                      variant="filled"
+                      sx={{
+                        fontSize: 12,
+                        height: 22,
+                        bgcolor: theme.palette.status.error.bg,
+                        color: theme.palette.status.error.main,
+                        borderRadius: 1,
+                        fontWeight: 500,
+                      }}
+                    />
+                  )}
                 </Box>
 
                 {emp.email && (
@@ -173,7 +203,6 @@ export default function CompanyMemberList({
         anchorEl={anchorEl}
         open={Boolean(anchorEl)}
         onClose={handleMenuClose}
-        onExited={handleMenuExited}
         anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
         transformOrigin={{ vertical: "top", horizontal: "right" }}
       >

--- a/src/features/project/home/components/CompanyMemberSectionContent.jsx
+++ b/src/features/project/home/components/CompanyMemberSectionContent.jsx
@@ -1,27 +1,102 @@
-// src/components/CompanyMemberSectionContent.jsx
-import React from "react";
-import { Grid, Typography, Divider, Box, Stack, Tooltip } from "@mui/material";
-import { InfoOutlined } from "@mui/icons-material";
-import CompanyMemberSelector from "./CompanyMemberSelector";
+import React, { useState, useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { useParams } from "react-router-dom";
+import {
+  Autocomplete,
+  Box,
+  Avatar,
+  Typography,
+  TextField,
+  CircularProgress,
+  IconButton,
+  Grid,
+  Stack,
+  Checkbox,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { useTheme } from "@mui/material/styles";
+import CompanyMemberList from "./CompanyMemberList";
+import { getCompanyMembersByCompanyId } from "@/api/member";
 
-/**
- * 공통 회사 정보 및 참여자 관리 섹션
- *
- * @param {string} companyLabel - 섹션 상단 텍스트 ("개발사", "고객사")
- * @param {string} companyName - 회사 이름
- * @param {string} contactNumber - 대표 번호
- * @param {string | undefined} tooltip - 툴팁 텍스트
- * @param {string} companyId - 참여자 로딩을 위한 회사 ID
- * @param {string} companyType - 참여자 API 요청 시 구분용 ("개발사", "고객사")
- */
 export default function CompanyMemberSectionContent({
   companyLabel = "회사",
   companyName,
   contactNumber,
-  tooltip,
   companyId,
   companyType,
+  setAssigned,
+  assigned,
 }) {
+  const dispatch = useDispatch();
+  const { id: projectId } = useParams();
+  const [members, setMembers] = useState([]); // 회사 직원 목록
+  const [loading, setLoading] = useState(false);
+  const [inputValue, setInputValue] = useState("");
+  const [open, setOpen] = useState(false); // Autocomplete 드롭다운 상태 제어
+  const theme = useTheme();
+
+  // 회사 전체 직원 목록을 가져옵니다.
+  useEffect(() => {
+    if (!companyId) return;
+
+    setLoading(true);
+    getCompanyMembersByCompanyId(companyId) // API로 회사 전체 직원 목록을 가져옵니다.
+      .then((res) => {
+        setMembers(res.data.data.members); // API 응답에서 직원 목록 저장
+      })
+      .finally(() => setLoading(false));
+  }, [companyId]);
+
+  const handleOpen = () => setOpen(true);
+
+  // 직원 선택 및 해제 처리
+  const handleChange = (_e, newValue) => {
+    const updatedAssigned = assigned.map((emp) => {
+      // 새로운 값이 선택되면 해당 id의 직원은 isDelete: false로 수정
+      if (newValue.some((newEmp) => newEmp.memberId === emp.memberId)) {
+        return { ...emp, isDelete: false }; // isDelete를 false로 업데이트
+      }
+      return emp; // 선택되지 않으면 그대로 유지
+    });
+
+    // 새로 선택된 직원은 추가, isNew: true, isDelete: false로 설정
+    const newEmployees = newValue
+      .filter((emp) => !assigned.some((a) => a.memberId === emp.memberId))
+      .map((emp) => ({
+        ...emp,
+        isNew: true, // 새로 선택된 직원은 isNew: true
+        isDelete: false, // 새 직원은 isDelete: false
+      }));
+
+    // 선택 해제된 직원은 isDelete: true로 설정
+    const removedEmployees = assigned
+      .filter(
+        (emp) => !newValue.some((newEmp) => newEmp.memberId === emp.memberId)
+      )
+      .map((emp) => ({
+        ...emp,
+        isDelete: true, // 선택 해제된 직원은 isDelete: true
+      }));
+
+    // 새로운 직원 목록과 기존 직원 목록을 병합해서 할당
+    setAssigned([...updatedAssigned, ...newEmployees, ...removedEmployees]);
+  };
+
+  const handleCheckboxChange = (option, selected) => {
+    const updatedAssigned = assigned.map((emp) => {
+      if (emp.memberId === option.id) {
+        // 체크된 경우, isDelete를 false로 설정
+        return selected
+          ? { ...emp, isDelete: false }
+          : { ...emp, isDelete: true }; // 체크 해제된 경우 isDelete를 true로 설정
+      }
+      return emp; // 해당 직원이 아니면 그대로 유지
+    });
+
+    setAssigned(updatedAssigned);
+  };
+  console.log("assigned", assigned);
+
   return (
     <Box>
       <Grid container spacing={3} sx={{ mb: 3 }}>
@@ -38,7 +113,100 @@ export default function CompanyMemberSectionContent({
           <Typography variant="body1">{contactNumber || "-"}</Typography>
         </Grid>
       </Grid>
-      <CompanyMemberSelector companyId={companyId} companyType={companyType} />
+
+      <Stack spacing={2}>
+        <Autocomplete
+          multiple
+          open={open}
+          onOpen={handleOpen}
+          onClose={() => setOpen(false)}
+          options={members} // API에서 가져온 전체 직원 목록을 사용
+          loading={loading}
+          inputValue={inputValue}
+          disableClearable
+          clearIcon={null}
+          getOptionLabel={(opt) => opt.name || ""} // 기본값을 보장하기 위해 '' 처리
+          isOptionEqualToValue={(opt, val) => opt.id === val.memberId}
+          value={assigned.filter((emp) => !emp.isDelete)} // 삭제되지 않은 직원만 표시
+          onChange={handleChange}
+          onInputChange={(_, val) => setInputValue(val)}
+          disableCloseOnSelect // 선택 후 드롭다운이 닫히지 않도록 설정
+          // onBlur에서 close 방지
+          onBlur={(e) => e.preventDefault()} // 블러 시 드롭다운이 닫히지 않도록 처리
+          onClick={(e) => e.stopPropagation()} // 클릭 시 드롭다운이 닫히지 않도록 처리
+          renderOption={(props, option) => {
+            // assigned에서 해당 직원 찾기
+            const assignedEmployee = assigned.find(
+              (emp) => emp.memberId === option.id
+            );
+            const isChecked = assignedEmployee
+              ? !assignedEmployee.isDelete
+              : false; // isDelete가 true이면 체크 해제
+
+            return (
+              <Box
+                component="li"
+                {...props}
+                key={option.id} // 여기에 key를 추가
+                sx={{ display: "flex", alignItems: "center", py: 0.5 }}
+              >
+                <Typography sx={{ flexGrow: 1 }}>{option.name}</Typography>
+                <Checkbox
+                  checked={isChecked} // assigned.isDelete에 따라 체크박스 상태 변경
+                  onChange={() => handleCheckboxChange(option, !isChecked)} // 체크박스 변경 처리
+                  color="primary"
+                />
+              </Box>
+            );
+          }}
+          renderTags={() => null}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              placeholder={`${companyType} 직원 이름 검색`}
+              size="small"
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {loading && <CircularProgress size={20} />}
+                    {inputValue && (
+                      <IconButton
+                        size="small"
+                        onClick={() => setInputValue("")}
+                      >
+                        <CloseIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+            />
+          )}
+          sx={{
+            width: { xs: "100%", sm: 360 },
+            "& .MuiOutlinedInput-root": {
+              bgcolor: theme.palette.background.paper,
+            },
+          }}
+        />
+
+        <Box sx={{ mt: 2 }}>
+          <CompanyMemberList
+            selectedEmployees={assigned
+              .filter((emp) => !emp.isDelete)
+              .map((emp) => ({
+                id: emp.memberId,
+                name: emp.memberName,
+                email: emp.email,
+                isManager: emp.isManager,
+                memberRole: emp.memberRole,
+              }))}
+            setAssigned={setAssigned}
+          />
+        </Box>
+      </Stack>
     </Box>
   );
 }

--- a/src/features/project/home/components/CompanyMemberSelector.jsx
+++ b/src/features/project/home/components/CompanyMemberSelector.jsx
@@ -3,8 +3,6 @@ import { useDispatch } from "react-redux";
 import { useParams } from "react-router-dom";
 import {
   fetchProjectMemberList,
-  addMemberToProject,
-  removeMemberFromProject,
   fetchCompanyMembersInProject,
 } from "@/features/project/slices/projectMemberSlice";
 import {
@@ -15,46 +13,51 @@ import {
   TextField,
   CircularProgress,
   IconButton,
+  Grid,
+  Stack,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import { useTheme as useMuiTheme } from "@mui/material/styles";
+import { useTheme } from "@mui/material/styles";
 import CompanyMemberList from "./CompanyMemberList";
-import { updateProjectManager } from "@/api/projectMember";
-import ConfirmDialog from "@/components/common/confirmDialog/ConfirmDialog";
-import AlertMessage from "@/components/common/alertMessage/AlertMessage";
 
 /**
- * @param {string} companyId
- * @param {'고객사'|'개발사'} companyType
+ * 공통 회사 정보 및 참여자 관리 섹션
+ *
+ * @param {string} companyLabel - 섹션 상단 텍스트 ("개발사", "고객사")
+ * @param {string} companyName - 회사 이름
+ * @param {string} contactNumber - 대표 번호
+ * @param {string | undefined} tooltip - 툴팁 텍스트
+ * @param {string} companyId - 참여자 로딩을 위한 회사 ID
+ * @param {string} companyType - 참여자 API 요청 시 구분용 ("개발사", "고객사")
+ * @param {function} setAssigned - 부모 컴포넌트로 직원 목록 업데이트하는 함수
+ * @param {array} assigned - 현재 할당된 직원 목록
  */
-export default function CompanyMemberSelector({
+export default function CompanyMemberSectionContent({
+  companyLabel = "회사",
+  companyName,
+  contactNumber,
   companyId,
-  companyType = "개발사",
+  companyType,
+  setAssigned,
+  assigned,
 }) {
-  const theme = useMuiTheme();
   const dispatch = useDispatch();
   const { id: projectId } = useParams();
-
   const [options, setOptions] = useState([]);
   const [loading, setLoading] = useState(false);
-  const [assigned, setAssigned] = useState([]);
   const [inputValue, setInputValue] = useState("");
   const [open, setOpen] = useState(false);
-  const [confirmOpen, setConfirmOpen] = useState(false);
-  const [confirmMsg, setConfirmMsg] = useState("");
-  const [pendingEmp, setPendingEmp] = useState(null);
-  const [alertOpen, setAlertOpen] = useState(false);
-  const [alertMsg, setAlertMsg] = useState("");
 
-  const extractMembers = (payload) =>
-    Array.isArray(payload) ? payload : payload?.members || [];
+  const theme = useTheme();
 
+  // 직원 목록을 불러오는 useEffect
   useEffect(() => {
     if (!companyId || !projectId) return;
+
     dispatch(fetchCompanyMembersInProject({ projectId, companyId })).then(
       (action) => {
-        const members = extractMembers(action.payload);
-        setAssigned(members);
+        const members = action.payload.members || [];
+        setOptions(members); // 전체 직원 목록을 options로 설정
       }
     );
   }, [companyId, projectId, dispatch]);
@@ -65,158 +68,144 @@ export default function CompanyMemberSelector({
 
     setLoading(true);
     dispatch(fetchProjectMemberList({ companyId, projectId }))
-      .then((action) => setOptions(extractMembers(action.payload)))
+      .then((action) => setOptions(action.payload.members || []))
       .finally(() => setLoading(false));
   };
 
-  const handleChange = async (_e, newValue) => {
-    const additions = newValue.filter(
-      (nv) => !assigned.some((a) => a.memberId === nv.memberId)
-    );
-    
-    // 새로 추가된 직원들을 서버에 추가
-    for (const emp of additions) {
-      await dispatch(addMemberToProject({ projectId, memberId: emp.memberId }));
-    }
-    
-    // 직원 추가 후 상세 정보를 다시 가져와서 assigned 상태 업데이트
-    if (additions.length > 0) {
-      const action = await dispatch(fetchCompanyMembersInProject({ projectId, companyId }));
-      const members = extractMembers(action.payload);
-      setAssigned(members);
-    } else {
-      setAssigned(newValue);
-    }
-    
-    setOpen(false);
+  // 체크박스 상태 변화 처리
+  const handleChange = (_e, newValue) => {
+    // 상태를 새롭게 업데이트하려면, 기존 assigned를 변경하지 않고 새로 만들어서 반영
+    const updatedAssigned = assigned.map((emp) => {
+      if (newValue.some((nv) => nv.memberId === emp.memberId)) {
+        return { ...emp, isDelete: false }; // 선택된 직원은 isDelete를 false로 설정
+      }
+      return emp; // 선택되지 않으면 그대로 유지
+    });
+
+    // 새로 선택된 직원은 isNew: true, isDelete: false로 추가
+    newValue.forEach((newEmp) => {
+      if (!assigned.some((emp) => emp.memberId === newEmp.memberId)) {
+        updatedAssigned.push({ ...newEmp, isNew: true, isDelete: false });
+      }
+    });
+
+    // 선택 해제된 직원은 isDelete: true로 설정
+    assigned.forEach((emp) => {
+      if (!newValue.some((nv) => nv.memberId === emp.memberId)) {
+        emp.isDelete = true;
+      }
+    });
+
+    // 상태 업데이트
+    setAssigned(updatedAssigned); // 부모 컴포넌트에 반영
+    setOpen(false); // 드롭다운 닫기
   };
+
+  console.log("assigned", assigned);
 
   const handleRemove = (memberId) => {
-    dispatch(removeMemberFromProject({ projectId, memberId }));
-    setAssigned((prev) => prev.filter((emp) => emp.memberId !== memberId));
-  };
+    const updatedAssigned = assigned.map((emp) => {
+      if (emp.memberId === memberId) {
+        return { ...emp, isDelete: true }; // 직원 삭제 시 isDelete를 true로 설정
+      }
+      return emp;
+    });
 
-  const toggleManager = (emp) => {
-    const msg = emp.isManager
-      ? "매니저를 해임 하시겠습니까?"
-      : "매니저를 임명 하시겠습니까?";
-    setConfirmMsg(msg);
-    setPendingEmp(emp);
-    setConfirmOpen(true);
+    setAssigned(updatedAssigned); // 부모 컴포넌트에 반영
   };
-
-  const handleConfirm = async () => {
-    if (!pendingEmp) return;
-    try {
-      await updateProjectManager({ memberId: pendingEmp.id, projectId });
-      setAssigned((prev) =>
-        prev.map((e) =>
-          e.memberId === pendingEmp.id ? { ...e, isManager: !e.isManager } : e
-        )
-      );
-    } catch {
-      setAlertMsg("매니저 상태 변경에 실패했습니다.");
-      setAlertOpen(true);
-    } finally {
-      setConfirmOpen(false);
-      setPendingEmp(null);
-    }
-  };
-
-  const getInitial = (name) => (name?.length ? name[0] : "?");
 
   return (
     <Box>
-      <Autocomplete
-        multiple
-        open={open}
-        onOpen={handleOpen}
-        onClose={() => setOpen(false)}
-        options={options}
-        loading={loading}
-        value={assigned}
-        inputValue={inputValue}
-        disableClearable
-        clearIcon={null}
-        getOptionLabel={(opt) => opt.memberName}
-        isOptionEqualToValue={(opt, val) => opt.memberId === val.memberId}
-        onChange={handleChange}
-        onInputChange={(_, val) => setInputValue(val)}
-        renderOption={(props, option, { selected }) => (
-          <Box
-            component="li"
-            {...props}
-            sx={{ display: "flex", alignItems: "center", py: 0.5 }}
-          >
-            <Avatar sx={{ width: 30, height: 30, mr: 1 }}>
-              {getInitial(option.memberName)}
-            </Avatar>
-            <Typography sx={{ flexGrow: 1 }}>{option.memberName}</Typography>
-            {selected && (
-              <Typography variant="caption" color="primary">
-                선택됨
-              </Typography>
-            )}
-          </Box>
-        )}
-        renderTags={() => null}
-        renderInput={(params) => (
-          <TextField
-            {...params}
-            placeholder={`${companyType} 직원 이름 검색`}
-            size="small"
-            InputProps={{
-              ...params.InputProps,
-              endAdornment: (
-                <>
-                  {loading && <CircularProgress size={20} />}
-                  {inputValue && (
-                    <IconButton size="small" onClick={() => setInputValue("")}>
-                      <CloseIcon fontSize="small" />
-                    </IconButton>
-                  )}
-                  {params.InputProps.endAdornment}
-                </>
-              ),
-            }}
-          />
-        )}
-        sx={{
-          width: { xs: "100%", sm: 360 },
-          "& .MuiOutlinedInput-root": {
-            bgcolor: theme.palette.background.paper,
-          },
-        }}
-      />
+      <Grid container spacing={3} sx={{ mb: 3 }}>
+        <Grid item xs={12} sm={6}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+            {companyLabel} 이름
+          </Typography>
+          <Typography variant="body1">{companyName || "-"}</Typography>
+        </Grid>
+        <Grid item xs={12} sm={6}>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+            대표 연락처
+          </Typography>
+          <Typography variant="body1">{contactNumber || "-"}</Typography>
+        </Grid>
+      </Grid>
 
-      <Box sx={{ mt: 2 }}>
-        <CompanyMemberList
-          selectedEmployees={assigned.map((emp) => ({
-            id: emp.memberId,
-            name: emp.memberName,
-            email: emp.email,
-            isManager: emp.isManager,
-            memberRole: emp.memberRole,
-          }))}
-          onRemove={handleRemove}
-          onToggleManager={toggleManager}
+      <Stack spacing={2}>
+        <Autocomplete
+          multiple
+          open={open}
+          onOpen={handleOpen}
+          onClose={() => setOpen(false)}
+          options={options}
+          loading={loading}
+          value={assigned.filter((emp) => !emp.isDelete)} // isDelete가 false인 직원만 표시
+          inputValue={inputValue}
+          disableClearable
+          clearIcon={null}
+          getOptionLabel={(opt) => opt.name}
+          isOptionEqualToValue={(opt, val) => opt.id === val.memberId}
+          onChange={handleChange}
+          onInputChange={(_, val) => setInputValue(val)}
+          renderOption={(props, option, { selected }) => (
+            <Box
+              component="li"
+              {...props}
+              key={option.id}
+              sx={{ display: "flex", alignItems: "center", py: 0.5 }}
+            >
+              <Avatar sx={{ width: 30, height: 30, mr: 1 }}>
+                {option.memberName[0]}
+              </Avatar>
+              <Typography sx={{ flexGrow: 1 }}>{option.memberName}</Typography>
+              {selected && (
+                <Typography variant="caption" color="primary">
+                  선택됨
+                </Typography>
+              )}
+            </Box>
+          )}
+          renderTags={() => null}
+          renderInput={(params) => (
+            <TextField
+              {...params}
+              placeholder={`${companyType} 직원 이름 검색`}
+              size="small"
+              InputProps={{
+                ...params.InputProps,
+                endAdornment: (
+                  <>
+                    {loading && <CircularProgress size={20} />}
+                    {inputValue && (
+                      <IconButton
+                        size="small"
+                        onClick={() => setInputValue("")}
+                      >
+                        <CloseIcon fontSize="small" />
+                      </IconButton>
+                    )}
+                    {params.InputProps.endAdornment}
+                  </>
+                ),
+              }}
+            />
+          )}
+          sx={{
+            width: { xs: "100%", sm: 360 },
+            "& .MuiOutlinedInput-root": {
+              bgcolor: theme.palette.background.paper,
+            },
+          }}
         />
-      </Box>
-      <ConfirmDialog
-        open={confirmOpen}
-        onClose={() => setConfirmOpen(false)}
-        onConfirm={handleConfirm}
-        title="매니저 임명/해임"
-        description={confirmMsg}
-        confirmText="확인"
-        confirmKind="primary"
-      />
-      <AlertMessage
-        open={alertOpen}
-        onClose={() => setAlertOpen(false)}
-        message={alertMsg}
-        severity="error"
-      />
+
+        <Box sx={{ mt: 2 }}>
+          <CompanyMemberList
+            selectedEmployees={assigned.filter((emp) => !emp.isDelete)} // isDelete가 false인 직원만 표시
+            onRemove={handleRemove} // 직원 제거 함수
+            setAssigned={setAssigned} // 부모에서 전달된 setAssigned
+          />
+        </Box>
+      </Stack>
     </Box>
   );
 }

--- a/src/features/project/home/hooks/useProjectDetailSections.jsx
+++ b/src/features/project/home/hooks/useProjectDetailSections.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import ProjectStepManager from "../components/ProjectStepManager/ProjectStepManager";
 import ProjectBasicInfoSectionContent from "../components/ProjectBasicInfoSectionContent";
 import CompanyMemberSectionContent from "../components/CompanyMemberSectionContent";
@@ -18,7 +17,11 @@ export default function useProjectDetailSections(
   steps,
   setSteps,
   initialSteps,
-  setPendingStep
+  setPendingStep,
+  devAssigned,
+  clientAssigned,
+  setDevAssigned,
+  setClientAssigned
 ) {
   const hasRole = (section) =>
     !section.roles || section.roles.includes(memberRole);
@@ -76,6 +79,8 @@ export default function useProjectDetailSections(
           companyId={project?.devCompanyId}
           companyType="개발사"
           tooltip="개발사 직원 정보를 확인하고 참여 인원을 설정할 수 있습니다."
+          assigned={devAssigned} // 개발사 직원만 전달
+          setAssigned={setDevAssigned} // setDevAssigned 전달
         />
       ),
     },
@@ -92,6 +97,8 @@ export default function useProjectDetailSections(
           companyId={project?.clientCompanyId}
           companyType="고객사"
           tooltip="고객사 직원 정보를 확인하고 참여 인원을 설정할 수 있습니다."
+          assigned={clientAssigned} // 고객사 직원만 전달
+          setAssigned={setClientAssigned} // setClientAssigned 전달
         />
       ),
     },

--- a/src/features/project/home/pages/ProjectDetailPage.jsx
+++ b/src/features/project/home/pages/ProjectDetailPage.jsx
@@ -28,8 +28,13 @@ export default function ProjectDetailPage() {
     setSteps,
     initialSteps,
     setPendingStep,
+    devAssigned, // 개발사 직원 상태
+    clientAssigned, // 고객사 직원 상태
+    setDevAssigned, // 개발사 직원 상태 변경 함수
+    setClientAssigned, // 고객사 직원 상태 변경 함수
   } = useProjectForm(id);
 
+  // sections 생성
   const sections = useProjectDetailSections(
     project,
     user?.role,
@@ -41,7 +46,11 @@ export default function ProjectDetailPage() {
     steps,
     setSteps,
     initialSteps,
-    setPendingStep
+    setPendingStep,
+    devAssigned,
+    clientAssigned,
+    setDevAssigned,
+    setClientAssigned
   );
 
   if (!id || loading || !project) {

--- a/src/features/project/slices/projectMemberSlice.js
+++ b/src/features/project/slices/projectMemberSlice.js
@@ -87,7 +87,7 @@ const projectMemberSlice = createSlice({
       })
       .addCase(fetchCompanyMembersInProject.fulfilled, (state, action) => {
         state.loading = false;
-        state.companyMembers = action.payload.companyMembers;
+        state.companyMembers = action.payload.members;
       })
       .addCase(fetchCompanyMembersInProject.rejected, (state, action) => {
         state.loading = false;

--- a/src/hooks/usePostForm.js
+++ b/src/hooks/usePostForm.js
@@ -1,147 +1,280 @@
-import { useState, useEffect } from "react";
+import { useEffect, useState, useMemo, useCallback } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import dayjs from "dayjs";
 import {
-  updateFileItem,
-  getUniqueFiles,
-  convertToFileItems,
-} from "@/utils/fileUploadUtils";
-import { validateFile } from "@/utils/validateFile";
-import { uploadFileWithPresignedUrl } from "@/utils/uploadFileWithPresignedUrl";
+  fetchProjectById,
+  updateProject,
+} from "@/features/project/slices/projectSlice";
 import {
-  createPostId,
-  deleteAttachment,
-} from "@/features/project/post/postSlice";
+  createProjectStages,
+  updateProjectStages,
+  fetchProjectStages,
+} from "@/features/project/slices/projectStepSlice";
+import {
+  addMemberToProject,
+  removeMemberFromProject,
+  fetchCompanyMembersInProject,
+} from "@/features/project/slices/projectMemberSlice";
 
-export default function usePostForm({ dispatch, open }) {
-  const [form, setForm] = useState({
-    id: "",
-    projectStepId: "",
-    title: "",
-    content: "",
+export default function useProjectForm(projectId) {
+  const dispatch = useDispatch();
+  const { current: project, loading } = useSelector((state) => state.project);
+  const fetchedSteps = useSelector((state) => state.projectStep.items) || [];
+
+  // 기본 프로젝트 값
+  const [values, setValues] = useState({
+    name: "",
+    detail: "",
+    startAt: "",
+    endAt: "",
+    projectAmount: "",
+    step: "CONTRACT",
   });
-  const [files, setFiles] = useState([]);
-  const [loadingId, setLoadingId] = useState(false);
-  const [previewModal, setPreviewModal] = useState({
-    open: false,
-    attachment: null,
-  });
 
-  const handleChange = (key) => (e) =>
-    setForm((prev) => ({ ...prev, [key]: e.target.value }));
+  // 프로젝트 단계 관리
+  const [steps, setSteps] = useState([]);
+  const [initialSteps, setInitialSteps] = useState([]);
+  const [stepEdited, setStepEdited] = useState(false);
+  const [stepSaveFn, setStepSaveFn] = useState(() => async () => {}); // 초기 값 설정
+  const [pendingStep, setPendingStep] = useState(null);
 
-  const generatePostId = async () => {
-    setLoadingId(true);
-    try {
-      const result = await dispatch(createPostId()).unwrap();
-      const newId = typeof result === "string" ? result : result.postId;
-      setForm((prev) => ({ ...prev, id: newId }));
-    } finally {
-      setLoadingId(false);
+  // 직원 상태 관리 (개발사, 고객사만 나누어 관리)
+  const [devAssigned, setDevAssigned] = useState([]); // 개발사 직원
+  const [clientAssigned, setClientAssigned] = useState([]); // 고객사 직원
+
+  // 프로젝트 및 단계 정보 불러오기
+  useEffect(() => {
+    if (projectId) {
+      dispatch(fetchProjectById(projectId));
+      dispatch(fetchProjectStages(projectId));
     }
-  };
+  }, [dispatch, projectId]);
 
-  const handleFileSelect = async (event) => {
-    const selectedFiles = Array.from(event.target.files);
-    const validFiles = [];
-    const invalidFiles = [];
-
-    selectedFiles.forEach((file) => {
-      const errors = validateFile(file);
-      if (errors.length === 0) validFiles.push(file);
-      else invalidFiles.push({ file, errors });
-    });
-
-    if (invalidFiles.length > 0) {
-      const errorMessages = invalidFiles
-        .map(({ file, errors }) => `${file.name}: ${errors.join(", ")}`)
-        .join("\n");
-      alert(`다음 파일들의 업로드가 실패했습니다:\n\n${errorMessages}`);
-    }
-
-    const newFiles = getUniqueFiles(validFiles, files);
-    if (newFiles.length !== validFiles.length) {
-      alert(
-        `${validFiles.length - newFiles.length}개의 파일이 이미 선택되어 있습니다.`
-      );
-    }
-
-    if (newFiles.length === 0) return;
-
-    const newFileItems = convertToFileItems(newFiles);
-    setFiles((prev) => [...prev, ...newFileItems]);
-
-    for (const fileItem of newFileItems) {
-      await uploadFileWithPresignedUrl({
-        fileItem,
-        postId: form.id,
-        updateFile: (id, updated) =>
-          setFiles((prev) => updateFileItem(prev, id, updated)),
-      });
-    }
-  };
-
-  const handleFileDelete = async (fileId) => {
-    const fileToDelete = files.find((file) => file.id === fileId);
-    if (!fileToDelete) return;
-    if (!window.confirm(`"${fileToDelete.name}" 파일을 삭제하시겠습니까?`))
+  // 회사 직원 목록 불러오기 (개발사, 고객사)
+  useEffect(() => {
+    if (
+      !project?.devCompanyId ||
+      !project?.clientCompanyId ||
+      !project.projectId
+    )
       return;
 
-    try {
-      if (fileToDelete.status === "success" && fileToDelete.postAttachmentId) {
-        await dispatch(
-          deleteAttachment(fileToDelete.postAttachmentId)
-        ).unwrap();
-      }
-      setFiles((prev) => prev.filter((file) => file.id !== fileId));
-    } catch {
-      alert("파일 삭제에 실패했습니다.");
-    }
-  };
+    // Fetch development company members
+    dispatch(
+      fetchCompanyMembersInProject({
+        projectId: project.projectId,
+        companyId: project?.devCompanyId,
+      })
+    ).then((action) => {
+      const devMembers = action.payload.members || [];
+      // isNew 값을 false로 설정하여 초기화
+      const devMembersWithSelection = devMembers.map((member) => ({
+        ...member,
+        isNew: false, // isNew를 false로 설정
+        isDelete: false, // 이미 선택된 상태로 설정
+      }));
 
-  const handleFileRetry = async (fileId) => {
-    const fileItem = files.find((file) => file.id === fileId);
-    if (fileItem) {
-      await uploadFileWithPresignedUrl({
-        fileItem,
-        postId: form.id,
-        updateFile: (id, updated) =>
-          setFiles((prev) => updateFileItem(prev, id, updated)),
+      setDevAssigned(devMembersWithSelection);
+    });
+
+    // Fetch client company members
+    dispatch(
+      fetchCompanyMembersInProject({
+        projectId: project.projectId,
+        companyId: project?.clientCompanyId,
+      })
+    ).then((action) => {
+      const clientMembers = action.payload.members || [];
+      // isNew 값을 false로 설정하여 초기화
+      const clientMembersWithSelection = clientMembers.map((member) => ({
+        ...member,
+        isNew: false, // isNew를 false로 설정
+        isDelete: false, // 이미 선택된 상태로 설정
+      }));
+
+      setClientAssigned(clientMembersWithSelection);
+    });
+  }, [dispatch, project]);
+
+  // 프로젝트 단계 정보 정리
+  useEffect(() => {
+    if (fetchedSteps.length > 0 && initialSteps.length === 0) {
+      const normalized = fetchedSteps.map((s) => ({
+        ...s,
+        orderNumber: s.orderNumber ?? s.orderNum,
+      }));
+      const sorted = normalized.sort((a, b) => a.orderNumber - b.orderNumber);
+      setSteps(sorted);
+      setInitialSteps(sorted);
+    } else {
+      const normalized = fetchedSteps.map((s) => ({
+        ...s,
+        orderNumber: s.orderNumber ?? s.orderNum,
+      }));
+      const sorted = normalized.sort((a, b) => a.orderNumber - b.orderNumber);
+      setSteps(sorted);
+    }
+  }, [fetchedSteps]);
+
+  // 프로젝트 데이터 세팅
+  useEffect(() => {
+    if (project) {
+      setValues({
+        name: project.name ?? "",
+        detail: project.detail ?? "",
+        startAt: dayjs(project.startAt).format("YYYY-MM-DD") || "",
+        endAt: dayjs(project.endAt).format("YYYY-MM-DD") || "",
+        projectAmount: project.projectAmount ?? "",
+        step: project.step || "CONTRACT",
       });
     }
+  }, [project]);
+
+  // 프로젝트 필드 값 변경
+  const setField = (field, value) => {
+    setValues((prev) => ({ ...prev, [field]: value }));
   };
 
-  const handlePreviewOpen = (file) => {
-    setPreviewModal({
-      open: true,
-      attachment: {
-        fileName: file.name,
-        fileSize: file.size,
-        fileType: file.type,
-        imageUrl: URL.createObjectURL(file.file),
-      },
+  // 프로젝트가 수정되었는지 확인
+  const isEdited = useMemo(() => {
+    if (!project) return false;
+
+    const fieldsChanged =
+      project.name !== values.name ||
+      project.detail !== values.detail ||
+      dayjs(project.startAt).format("YYYY-MM-DD") !== values.startAt ||
+      dayjs(project.endAt).format("YYYY-MM-DD") !== values.endAt ||
+      project.projectAmount !== values.projectAmount ||
+      project.step !== values.step;
+
+    const employeeChanged =
+      devAssigned.some((emp) => emp.isNew || emp.isDeleted) ||
+      clientAssigned.some((emp) => emp.isNew || emp.isDeleted); // 직원 변경 감지 (새로 추가된 직원이나 삭제된 직원)
+
+    return (
+      fieldsChanged || stepEdited || pendingStep !== null || employeeChanged
+    );
+  }, [project, values, stepEdited, pendingStep, devAssigned, clientAssigned]);
+
+  // 프로젝트 값 초기화
+  const reset = () => {
+    if (!project) return;
+
+    setValues({
+      name: project.name ?? "",
+      detail: project.detail ?? "",
+      startAt: dayjs(project.startAt).format("YYYY-MM-DD") || "",
+      endAt: dayjs(project.endAt).format("YYYY-MM-DD") || "",
+      projectAmount: project.projectAmount ?? "",
+      step: project.step || "CONTRACT",
     });
+
+    setSteps(initialSteps);
+    setStepEdited(false);
+    setPendingStep(null);
   };
 
-  const handlePreviewClose = () => {
-    URL.revokeObjectURL(previewModal.attachment?.imageUrl);
-    setPreviewModal({ open: false, attachment: null });
-  };
+  // 프로젝트 저장
+  const save = useCallback(async () => {
+    try {
+      const payload = {
+        id: projectId,
+        name: values.name,
+        detail: values.detail,
+        ...(values.startAt && { startAt: `${values.startAt}T09:00:00` }),
+        ...(values.endAt && { endAt: `${values.endAt}T18:00:00` }),
+        projectAmount:
+          values.projectAmount === "" ? null : Number(values.projectAmount),
+        step: values.step,
+        deleted: false,
+      };
 
-  useEffect(() => {
-    if (open) generatePostId();
-  }, [open]);
+      await dispatch(updateProject(payload)).unwrap();
+
+      const newSteps = steps.filter((s) => s.isNew);
+      const existingSteps = steps.filter((s) => !s.isNew);
+
+      if (newSteps.length > 0) {
+        await dispatch(
+          createProjectStages({
+            projectId,
+            projectSteps: newSteps.map((s) => ({
+              title: s.title,
+              orderNumber: s.orderNumber,
+            })),
+          })
+        ).unwrap();
+      }
+
+      if (stepEdited || newSteps.length > 0) {
+        await dispatch(
+          updateProjectStages({
+            projectId,
+            projectStepUpdateWebRequests: existingSteps.map(
+              ({ projectStepId, title, orderNumber }) => ({
+                projectStepId,
+                title,
+                orderNumber,
+              })
+            ),
+          })
+        ).unwrap();
+      }
+
+      // 새로 추가된 직원 처리
+      const newAssignedEmployees = [
+        ...devAssigned.filter((emp) => emp.isNew),
+        ...clientAssigned.filter((emp) => emp.isNew),
+      ];
+      newAssignedEmployees.forEach((emp) => {
+        if (!emp.memberId) return;
+        dispatch(addMemberToProject({ projectId, memberId: emp.memberId }));
+      });
+
+      // 삭제된 직원 처리
+      const deletedEmployees = [
+        ...devAssigned.filter((emp) => emp.isDelete),
+        ...clientAssigned.filter((emp) => emp.isDelete),
+      ];
+      deletedEmployees.forEach((emp) => {
+        if (!emp.memberId) return;
+        dispatch(
+          removeMemberFromProject({ projectId, memberId: emp.memberId })
+        );
+      });
+
+      // 화면 새로고침
+      window.location.reload();
+    } catch (err) {
+      console.error("프로젝트 저장 실패:", err);
+    }
+  }, [
+    dispatch,
+    projectId,
+    values,
+    steps,
+    stepEdited,
+    devAssigned,
+    clientAssigned,
+  ]);
 
   return {
-    form,
-    setForm,
-    files,
-    setFiles,
-    loadingId,
-    previewModal,
-    handleChange,
-    handleFileSelect,
-    handleFileDelete,
-    handleFileRetry,
-    handlePreviewOpen,
-    handlePreviewClose,
+    loading,
+    project,
+    values,
+    setField,
+    isEdited,
+    reset,
+    save,
+    steps,
+    setSteps,
+    initialSteps,
+    setStepEdited,
+    setStepSaveFn,
+    setPendingStep,
+    devAssigned, // 개발사 직원
+    clientAssigned, // 고객사 직원
+    setDevAssigned, // 개발사 직원 상태 변경 함수
+    setClientAssigned, // 고객사 직원 상태 변경 함수
   };
 }


### PR DESCRIPTION
## 📌 개요

* 회사(개발사/고객사) 직원 관리 기능을 리팩토링하여
  초기 할당 상태를 추적하고, 선택된 직원 목록의 변경 여부를 감지·리셋할 수 있는 로직을 추가했습니다.

## 🛠️ 변경 사항

* `assigned` 상태의 초기값을 별도 변수(`initialAssigned`)로 저장
* 사용자가 직원 선택·해제 시 변경 여부(`isEdited`)를 자동으로 감지하도록 로직 구현
* “초기 상태로 리셋” 기능 추가: 변경 전 상태로 되돌리는 핸들러 제공
* Redux slice 및 컴포넌트 수준에서 선택된 직원 상태 관리 방식을 일원화
* 관련 유틸 및 훅(`useCompanyMemberSectionContent`) 내부 로직 클린업 및 주석 보강

## ✅ 주요 체크 포인트

* [ ] 직원 추가/제거 후 `isEdited` 플래그가 올바르게 토글되는지
* [ ] 리셋 버튼 클릭 시 초기 할당 상태로 정확히 복원되는지
* [ ] Redux DevTools에서 상태 변경 흐름이 의도대로 작동하는지
* [ ] UI에서 변경 감지·리셋 액션이 직관적으로 동작하는지

## 🔁 테스트 결과

* 직원 목록에서 여러 건 선택 → `isEdited=true` 확인
* 리셋 클릭 → 선택 목록이 초기값으로 복원되고, `isEdited=false` 확인
* 추가·삭제 반복 후에도 상태 안정성 유지
* 브라우저 콘솔 및 네트워크 패널 이상 없음

## 🔗 연관된 이슈

* #417 

## 📑 레퍼런스
없음