### PR TITLE
[refactor] useProjectForm 훅 및 직원 관리 컴포넌트 개선 (#417)

### DIFF
--- a/src/features/project/home/components/CompanyMemberList.jsx
+++ b/src/features/project/home/components/CompanyMemberList.jsx
@@ -1,16 +1,8 @@
-import React, { useState } from "react";
-import {
-  Box,
-  Typography,
-  IconButton,
-  Chip,
-  Menu,
-  MenuItem,
-} from "@mui/material";
+import React from "react";
+import { Box, Typography, Chip, IconButton } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
-import PersonAddAltRoundedIcon from "@mui/icons-material/PersonAddAltRounded";
-import DeleteRoundedIcon from "@mui/icons-material/DeleteRounded";
+import PersonAddOutlinedIcon from "@mui/icons-material/PersonAddOutlined";
+import PersonRemoveOutlinedIcon from "@mui/icons-material/PersonRemoveOutlined";
 
 const ROLE_LABEL_MAP = {
   DEV_ADMIN: "개발 관리자",
@@ -22,37 +14,10 @@ const ROLE_LABEL_MAP = {
 
 export default function CompanyMemberList({
   selectedEmployees,
-  onRemove,
   onToggleManager,
 }) {
   const theme = useTheme();
-  const [anchorEl, setAnchorEl] = useState(null);
-  const [menuTarget, setMenuTarget] = useState(null);
 
-  const handleMenuOpen = (event, emp) => {
-    setAnchorEl(event.currentTarget);
-    setMenuTarget(emp);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-  };
-
-  const handleToggleManager = () => {
-    if (onToggleManager && menuTarget) {
-      onToggleManager(menuTarget);
-    }
-    handleMenuClose();
-  };
-
-  const handleRemove = () => {
-    if (onRemove && menuTarget) {
-      onRemove(menuTarget.id);
-    }
-    handleMenuClose();
-  };
-
-  // 역할 색상 매핑
   const getRoleChipStyle = (role) => {
     switch (role) {
       case "DEV_ADMIN":
@@ -84,142 +49,87 @@ export default function CompanyMemberList({
     <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 1.5 }}>
       {selectedEmployees.map((emp) => {
         const roleLabel = ROLE_LABEL_MAP[emp.memberRole] || emp.memberRole;
+        const canToggleManager = emp.memberRole !== "USER";
         return (
           <Box
-            key={`${emp.id}-${emp.memberRole}`}
+            key={emp.memberId}
             sx={{
+              position: "relative",
               minWidth: 300,
               maxWidth: 300,
               minHeight: 80,
-              maxHeight: 100,
-              flex: "1 0 120px",
+              maxHeight: 80,
               border: `1px solid ${theme.palette.divider}`,
               borderRadius: 2,
               p: 2,
-              display: "flex",
-              flexDirection: "column",
-              justifyContent: "space-between",
               backgroundColor: theme.palette.background.paper,
-              boxSizing: "border-box",
             }}
           >
-            <Box
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "space-between",
-              }}
-            >
-              <Box sx={{ flex: 1, overflow: "hidden" }}>
-                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                  <Typography variant="body2" fontWeight={600} noWrap>
-                    {emp.name}
-                  </Typography>
-
-                  {/* 역할 Chip */}
-                  {emp.memberRole && (
-                    <Chip
-                      label={roleLabel}
-                      size="small"
-                      variant="filled"
-                      sx={{
-                        fontSize: 12,
-                        height: 22,
-                        ...getRoleChipStyle(emp.memberRole),
-                        borderRadius: 1,
-                        fontWeight: 500,
-                      }}
-                    />
-                  )}
-
-                  {/* 매니저 Chip */}
-                  {emp.isManager && (
-                    <Chip
-                      label="매니저"
-                      size="small"
-                      variant="filled"
-                      sx={{
-                        fontSize: 12,
-                        height: 22,
-                        bgcolor: theme.palette.status.error.bg,
-                        color: theme.palette.status.error.main,
-                        borderRadius: 1,
-                        fontWeight: 500,
-                      }}
-                    />
-                  )}
-
-                  {/* 새로운 직원 표시 */}
-                  {emp.isNew && (
-                    <Chip
-                      label="새로운 직원"
-                      size="small"
-                      variant="filled"
-                      sx={{
-                        fontSize: 12,
-                        height: 22,
-                        bgcolor: theme.palette.status.info.bg,
-                        color: theme.palette.status.info.main,
-                        borderRadius: 1,
-                        fontWeight: 500,
-                      }}
-                    />
-                  )}
-
-                  {/* 삭제된 직원 표시 */}
-                  {emp.isDeleted && (
-                    <Chip
-                      label="삭제됨"
-                      size="small"
-                      variant="filled"
-                      sx={{
-                        fontSize: 12,
-                        height: 22,
-                        bgcolor: theme.palette.status.error.bg,
-                        color: theme.palette.status.error.main,
-                        borderRadius: 1,
-                        fontWeight: 500,
-                      }}
-                    />
-                  )}
-                </Box>
-
-                {emp.email && (
-                  <Typography variant="caption" color="text.secondary" noWrap>
-                    {emp.email}
-                  </Typography>
+            {/* 토글 버튼 */}
+            {canToggleManager && (
+              <IconButton
+                size="small"
+                onClick={() => onToggleManager(emp.memberId)}
+                sx={{
+                  position: "absolute",
+                  top: 8,
+                  right: 8,
+                  color: emp.isManager
+                    ? theme.palette.primary.main
+                    : theme.palette.text.secondary,
+                }}
+              >
+                {emp.isManager ? (
+                  <PersonRemoveOutlinedIcon fontSize="small" />
+                ) : (
+                  <PersonAddOutlinedIcon fontSize="small" />
                 )}
-              </Box>
-
-              <IconButton size="small" onClick={(e) => handleMenuOpen(e, emp)}>
-                <MoreVertIcon fontSize="small" />
               </IconButton>
+            )}
+
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+              <Typography variant="body2" fontWeight={600} noWrap>
+                {emp.memberName || emp.name}
+              </Typography>
+              {emp.memberRole && (
+                <Chip
+                  label={roleLabel}
+                  size="small"
+                  variant="filled"
+                  sx={{
+                    fontSize: 12,
+                    height: 22,
+                    ...getRoleChipStyle(emp.memberRole),
+                    borderRadius: 1,
+                    fontWeight: 500,
+                  }}
+                />
+              )}
+              {emp.isManager && (
+                <Chip
+                  label="담당자"
+                  size="small"
+                  color="filled"
+                  sx={{
+                    fontSize: 12,
+                    height: 22,
+                    bgcolor: theme.palette.status.error.bg,
+                    color: theme.palette.status.error.main,
+                    borderRadius: 1,
+                    fontWeight: 500,
+                  }}
+                />
+              )}
             </Box>
+
+            {emp.email && (
+              <Typography variant="caption" color="text.secondary" noWrap>
+                {emp.email}
+              </Typography>
+            )}
           </Box>
         );
       })}
-
-      <Menu
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onClose={handleMenuClose}
-        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-        transformOrigin={{ vertical: "top", horizontal: "right" }}
-      >
-        {onToggleManager && menuTarget?.memberRole !== "USER" && (
-          <MenuItem onClick={handleToggleManager}>
-            <PersonAddAltRoundedIcon fontSize="small" sx={{ mr: 1 }} />
-            {menuTarget?.isManager ? "매니저 해임" : "매니저로 임명"}
-          </MenuItem>
-        )}
-        <MenuItem
-          onClick={handleRemove}
-          sx={{ color: theme.palette.error.main }}
-        >
-          <DeleteRoundedIcon fontSize="small" sx={{ mr: 1 }} />
-          삭제
-        </MenuItem>
-      </Menu>
     </Box>
   );
 }

--- a/src/features/project/home/components/CompanyMemberSectionContent.jsx
+++ b/src/features/project/home/components/CompanyMemberSectionContent.jsx
@@ -59,7 +59,7 @@ export default function CompanyMemberSectionContent({
           memberId: o.id,
           memberName: o.name,
           email: o.email,
-          isManager: o.isManager,
+          isManager: false,
           memberRole: o.memberRole,
           isNew: true,
           isDelete: false,
@@ -70,10 +70,19 @@ export default function CompanyMemberSectionContent({
     setAssigned(updated);
   };
 
-  // Autocomplete에 넘길 value: assigned 중 isDelete=false인 것들을 members에서 뽑아낸 option 객체
-  const selectedOptions = members.filter((m) =>
+  const compareOptions = members.filter((m) =>
     assigned.some((emp) => emp.memberId === m.id && !emp.isDelete)
   );
+
+  const handleToggleManager = (targetMemberId) => {
+    setAssigned(
+      assigned.map((emp) =>
+        emp.memberId === targetMemberId
+          ? { ...emp, isManager: !emp.isManager }
+          : emp
+      )
+    );
+  };
 
   return (
     <Box>
@@ -98,11 +107,12 @@ export default function CompanyMemberSectionContent({
         <Autocomplete
           multiple
           options={members}
-          value={selectedOptions}
+          value={compareOptions}
           loading={loading}
           inputValue={inputValue}
           onInputChange={(_, v) => setInputValue(v)}
           disableCloseOnSelect
+          disableClearable
           getOptionLabel={(opt) => opt.name}
           isOptionEqualToValue={(opt, val) => opt.id === val.id}
           onChange={handleChange}
@@ -158,14 +168,8 @@ export default function CompanyMemberSectionContent({
 
         <Box sx={{ mt: 2 }}>
           <CompanyMemberList
-            selectedEmployees={selectedOptions.map((opt) => ({
-              id: opt.id,
-              name: opt.name,
-              email: opt.email,
-              isManager: opt.isManager,
-              memberRole: opt.memberRole,
-            }))}
-            setAssigned={setAssigned}
+            selectedEmployees={assigned.filter((emp) => !emp.isDelete)}
+            onToggleManager={handleToggleManager}
           />
         </Box>
       </Stack>

--- a/src/hooks/usePostForm.js
+++ b/src/hooks/usePostForm.js
@@ -1,280 +1,147 @@
-import { useEffect, useState, useMemo, useCallback } from "react";
-import { useDispatch, useSelector } from "react-redux";
-import dayjs from "dayjs";
+import { useState, useEffect } from "react";
 import {
-  fetchProjectById,
-  updateProject,
-} from "@/features/project/slices/projectSlice";
+  updateFileItem,
+  getUniqueFiles,
+  convertToFileItems,
+} from "@/utils/fileUploadUtils";
+import { validateFile } from "@/utils/validateFile";
+import { uploadFileWithPresignedUrl } from "@/utils/uploadFileWithPresignedUrl";
 import {
-  createProjectStages,
-  updateProjectStages,
-  fetchProjectStages,
-} from "@/features/project/slices/projectStepSlice";
-import {
-  addMemberToProject,
-  removeMemberFromProject,
-  fetchCompanyMembersInProject,
-} from "@/features/project/slices/projectMemberSlice";
+  createPostId,
+  deleteAttachment,
+} from "@/features/project/post/postSlice";
 
-export default function useProjectForm(projectId) {
-  const dispatch = useDispatch();
-  const { current: project, loading } = useSelector((state) => state.project);
-  const fetchedSteps = useSelector((state) => state.projectStep.items) || [];
-
-  // 기본 프로젝트 값
-  const [values, setValues] = useState({
-    name: "",
-    detail: "",
-    startAt: "",
-    endAt: "",
-    projectAmount: "",
-    step: "CONTRACT",
+export default function usePostForm({ dispatch, open }) {
+  const [form, setForm] = useState({
+    id: "",
+    projectStepId: "",
+    title: "",
+    content: "",
+  });
+  const [files, setFiles] = useState([]);
+  const [loadingId, setLoadingId] = useState(false);
+  const [previewModal, setPreviewModal] = useState({
+    open: false,
+    attachment: null,
   });
 
-  // 프로젝트 단계 관리
-  const [steps, setSteps] = useState([]);
-  const [initialSteps, setInitialSteps] = useState([]);
-  const [stepEdited, setStepEdited] = useState(false);
-  const [stepSaveFn, setStepSaveFn] = useState(() => async () => {}); // 초기 값 설정
-  const [pendingStep, setPendingStep] = useState(null);
+  const handleChange = (key) => (e) =>
+    setForm((prev) => ({ ...prev, [key]: e.target.value }));
 
-  // 직원 상태 관리 (개발사, 고객사만 나누어 관리)
-  const [devAssigned, setDevAssigned] = useState([]); // 개발사 직원
-  const [clientAssigned, setClientAssigned] = useState([]); // 고객사 직원
-
-  // 프로젝트 및 단계 정보 불러오기
-  useEffect(() => {
-    if (projectId) {
-      dispatch(fetchProjectById(projectId));
-      dispatch(fetchProjectStages(projectId));
+  const generatePostId = async () => {
+    setLoadingId(true);
+    try {
+      const result = await dispatch(createPostId()).unwrap();
+      const newId = typeof result === "string" ? result : result.postId;
+      setForm((prev) => ({ ...prev, id: newId }));
+    } finally {
+      setLoadingId(false);
     }
-  }, [dispatch, projectId]);
+  };
 
-  // 회사 직원 목록 불러오기 (개발사, 고객사)
-  useEffect(() => {
-    if (
-      !project?.devCompanyId ||
-      !project?.clientCompanyId ||
-      !project.projectId
-    )
+  const handleFileSelect = async (event) => {
+    const selectedFiles = Array.from(event.target.files);
+    const validFiles = [];
+    const invalidFiles = [];
+
+    selectedFiles.forEach((file) => {
+      const errors = validateFile(file);
+      if (errors.length === 0) validFiles.push(file);
+      else invalidFiles.push({ file, errors });
+    });
+
+    if (invalidFiles.length > 0) {
+      const errorMessages = invalidFiles
+        .map(({ file, errors }) => `${file.name}: ${errors.join(", ")}`)
+        .join("\n");
+      alert(`다음 파일들의 업로드가 실패했습니다:\n\n${errorMessages}`);
+    }
+
+    const newFiles = getUniqueFiles(validFiles, files);
+    if (newFiles.length !== validFiles.length) {
+      alert(
+        `${validFiles.length - newFiles.length}개의 파일이 이미 선택되어 있습니다.`
+      );
+    }
+
+    if (newFiles.length === 0) return;
+
+    const newFileItems = convertToFileItems(newFiles);
+    setFiles((prev) => [...prev, ...newFileItems]);
+
+    for (const fileItem of newFileItems) {
+      await uploadFileWithPresignedUrl({
+        fileItem,
+        postId: form.id,
+        updateFile: (id, updated) =>
+          setFiles((prev) => updateFileItem(prev, id, updated)),
+      });
+    }
+  };
+
+  const handleFileDelete = async (fileId) => {
+    const fileToDelete = files.find((file) => file.id === fileId);
+    if (!fileToDelete) return;
+    if (!window.confirm(`"${fileToDelete.name}" 파일을 삭제하시겠습니까?`))
       return;
 
-    // Fetch development company members
-    dispatch(
-      fetchCompanyMembersInProject({
-        projectId: project.projectId,
-        companyId: project?.devCompanyId,
-      })
-    ).then((action) => {
-      const devMembers = action.payload.members || [];
-      // isNew 값을 false로 설정하여 초기화
-      const devMembersWithSelection = devMembers.map((member) => ({
-        ...member,
-        isNew: false, // isNew를 false로 설정
-        isDelete: false, // 이미 선택된 상태로 설정
-      }));
-
-      setDevAssigned(devMembersWithSelection);
-    });
-
-    // Fetch client company members
-    dispatch(
-      fetchCompanyMembersInProject({
-        projectId: project.projectId,
-        companyId: project?.clientCompanyId,
-      })
-    ).then((action) => {
-      const clientMembers = action.payload.members || [];
-      // isNew 값을 false로 설정하여 초기화
-      const clientMembersWithSelection = clientMembers.map((member) => ({
-        ...member,
-        isNew: false, // isNew를 false로 설정
-        isDelete: false, // 이미 선택된 상태로 설정
-      }));
-
-      setClientAssigned(clientMembersWithSelection);
-    });
-  }, [dispatch, project]);
-
-  // 프로젝트 단계 정보 정리
-  useEffect(() => {
-    if (fetchedSteps.length > 0 && initialSteps.length === 0) {
-      const normalized = fetchedSteps.map((s) => ({
-        ...s,
-        orderNumber: s.orderNumber ?? s.orderNum,
-      }));
-      const sorted = normalized.sort((a, b) => a.orderNumber - b.orderNumber);
-      setSteps(sorted);
-      setInitialSteps(sorted);
-    } else {
-      const normalized = fetchedSteps.map((s) => ({
-        ...s,
-        orderNumber: s.orderNumber ?? s.orderNum,
-      }));
-      const sorted = normalized.sort((a, b) => a.orderNumber - b.orderNumber);
-      setSteps(sorted);
-    }
-  }, [fetchedSteps]);
-
-  // 프로젝트 데이터 세팅
-  useEffect(() => {
-    if (project) {
-      setValues({
-        name: project.name ?? "",
-        detail: project.detail ?? "",
-        startAt: dayjs(project.startAt).format("YYYY-MM-DD") || "",
-        endAt: dayjs(project.endAt).format("YYYY-MM-DD") || "",
-        projectAmount: project.projectAmount ?? "",
-        step: project.step || "CONTRACT",
-      });
-    }
-  }, [project]);
-
-  // 프로젝트 필드 값 변경
-  const setField = (field, value) => {
-    setValues((prev) => ({ ...prev, [field]: value }));
-  };
-
-  // 프로젝트가 수정되었는지 확인
-  const isEdited = useMemo(() => {
-    if (!project) return false;
-
-    const fieldsChanged =
-      project.name !== values.name ||
-      project.detail !== values.detail ||
-      dayjs(project.startAt).format("YYYY-MM-DD") !== values.startAt ||
-      dayjs(project.endAt).format("YYYY-MM-DD") !== values.endAt ||
-      project.projectAmount !== values.projectAmount ||
-      project.step !== values.step;
-
-    const employeeChanged =
-      devAssigned.some((emp) => emp.isNew || emp.isDeleted) ||
-      clientAssigned.some((emp) => emp.isNew || emp.isDeleted); // 직원 변경 감지 (새로 추가된 직원이나 삭제된 직원)
-
-    return (
-      fieldsChanged || stepEdited || pendingStep !== null || employeeChanged
-    );
-  }, [project, values, stepEdited, pendingStep, devAssigned, clientAssigned]);
-
-  // 프로젝트 값 초기화
-  const reset = () => {
-    if (!project) return;
-
-    setValues({
-      name: project.name ?? "",
-      detail: project.detail ?? "",
-      startAt: dayjs(project.startAt).format("YYYY-MM-DD") || "",
-      endAt: dayjs(project.endAt).format("YYYY-MM-DD") || "",
-      projectAmount: project.projectAmount ?? "",
-      step: project.step || "CONTRACT",
-    });
-
-    setSteps(initialSteps);
-    setStepEdited(false);
-    setPendingStep(null);
-  };
-
-  // 프로젝트 저장
-  const save = useCallback(async () => {
     try {
-      const payload = {
-        id: projectId,
-        name: values.name,
-        detail: values.detail,
-        ...(values.startAt && { startAt: `${values.startAt}T09:00:00` }),
-        ...(values.endAt && { endAt: `${values.endAt}T18:00:00` }),
-        projectAmount:
-          values.projectAmount === "" ? null : Number(values.projectAmount),
-        step: values.step,
-        deleted: false,
-      };
-
-      await dispatch(updateProject(payload)).unwrap();
-
-      const newSteps = steps.filter((s) => s.isNew);
-      const existingSteps = steps.filter((s) => !s.isNew);
-
-      if (newSteps.length > 0) {
+      if (fileToDelete.status === "success" && fileToDelete.postAttachmentId) {
         await dispatch(
-          createProjectStages({
-            projectId,
-            projectSteps: newSteps.map((s) => ({
-              title: s.title,
-              orderNumber: s.orderNumber,
-            })),
-          })
+          deleteAttachment(fileToDelete.postAttachmentId)
         ).unwrap();
       }
-
-      if (stepEdited || newSteps.length > 0) {
-        await dispatch(
-          updateProjectStages({
-            projectId,
-            projectStepUpdateWebRequests: existingSteps.map(
-              ({ projectStepId, title, orderNumber }) => ({
-                projectStepId,
-                title,
-                orderNumber,
-              })
-            ),
-          })
-        ).unwrap();
-      }
-
-      // 새로 추가된 직원 처리
-      const newAssignedEmployees = [
-        ...devAssigned.filter((emp) => emp.isNew),
-        ...clientAssigned.filter((emp) => emp.isNew),
-      ];
-      newAssignedEmployees.forEach((emp) => {
-        if (!emp.memberId) return;
-        dispatch(addMemberToProject({ projectId, memberId: emp.memberId }));
-      });
-
-      // 삭제된 직원 처리
-      const deletedEmployees = [
-        ...devAssigned.filter((emp) => emp.isDelete),
-        ...clientAssigned.filter((emp) => emp.isDelete),
-      ];
-      deletedEmployees.forEach((emp) => {
-        if (!emp.memberId) return;
-        dispatch(
-          removeMemberFromProject({ projectId, memberId: emp.memberId })
-        );
-      });
-
-      // 화면 새로고침
-      window.location.reload();
-    } catch (err) {
-      console.error("프로젝트 저장 실패:", err);
+      setFiles((prev) => prev.filter((file) => file.id !== fileId));
+    } catch {
+      alert("파일 삭제에 실패했습니다.");
     }
-  }, [
-    dispatch,
-    projectId,
-    values,
-    steps,
-    stepEdited,
-    devAssigned,
-    clientAssigned,
-  ]);
+  };
+
+  const handleFileRetry = async (fileId) => {
+    const fileItem = files.find((file) => file.id === fileId);
+    if (fileItem) {
+      await uploadFileWithPresignedUrl({
+        fileItem,
+        postId: form.id,
+        updateFile: (id, updated) =>
+          setFiles((prev) => updateFileItem(prev, id, updated)),
+      });
+    }
+  };
+
+  const handlePreviewOpen = (file) => {
+    setPreviewModal({
+      open: true,
+      attachment: {
+        fileName: file.name,
+        fileSize: file.size,
+        fileType: file.type,
+        imageUrl: URL.createObjectURL(file.file),
+      },
+    });
+  };
+
+  const handlePreviewClose = () => {
+    URL.revokeObjectURL(previewModal.attachment?.imageUrl);
+    setPreviewModal({ open: false, attachment: null });
+  };
+
+  useEffect(() => {
+    if (open) generatePostId();
+  }, [open]);
 
   return {
-    loading,
-    project,
-    values,
-    setField,
-    isEdited,
-    reset,
-    save,
-    steps,
-    setSteps,
-    initialSteps,
-    setStepEdited,
-    setStepSaveFn,
-    setPendingStep,
-    devAssigned, // 개발사 직원
-    clientAssigned, // 고객사 직원
-    setDevAssigned, // 개발사 직원 상태 변경 함수
-    setClientAssigned, // 고객사 직원 상태 변경 함수
+    form,
+    setForm,
+    files,
+    setFiles,
+    loadingId,
+    previewModal,
+    handleChange,
+    handleFileSelect,
+    handleFileDelete,
+    handleFileRetry,
+    handlePreviewOpen,
+    handlePreviewClose,
   };
 }


### PR DESCRIPTION
## 📌 개요

* \#417 이슈와 연관하여 기존 `useProjectForm` 훅 로직을 최적화하고, 잘못 붙여넣어진 `usePostForm` 코드를 원상복구했습니다.
* 직원 선택/매니저 토글 로직을 개선하고, `CompanyMemberList` 컴포넌트를 단순화하여 유지보수성을 높였습니다.

## 🛠️ 변경 사항

* **useProjectForm 훅**

  * 단계 정리(useEffect)에서 `initialSteps.length` 조건 추가 및 else 분기 처리
  * `project.startAt`/`project.endAt` null 방어 로직 보강
  * `isEdited` 계산 시 필드 변경 여부 우선 검사 후 API 호출
  * 단계 생성·업데이트, 직원 추가·삭제 필터링 조건 강화(`isNew && !isDelete`, `!isNew && isDelete`)
* **usePostForm 리버트**

  * 잘못 붙여넣어진 `useProjectForm` 코드를 삭제하고 훅을 원래대로 되돌림
* **직원 선택 및 매니저 토글 로직**

  * `assigned` 초기화 시 `isManager: false` 고정
  * `compareOptions` 도입 및 Autocomplete `disableClearable` 옵션 추가
  * `handleToggleManager` 함수 정의 후 `onToggleManager` prop으로 분리
* **CompanyMemberList 컴포넌트**

  * 중첩된 레이아웃 구조 제거, `key` prop을 `memberId`로 통일
  * 메뉴(Menu) 및 `MoreVertIcon` 제거
  * 우측 상단에 `IconButton`으로 담당자 지정/해제 기능 통합 (`PersonAddOutlined` / `PersonRemoveOutlined`)
  * `canToggleManager` 조건 추가해 USER 역할 항목 제외

## ✅ 주요 체크 포인트

* `useProjectForm` 훅에서 단계 및 프로젝트 필드 변경 시 정상적으로 API가 호출되는지
* `usePostForm` 훅이 오류 없이 원래 기능만 수행하는지
* Autocomplete에서 직원 선택·해제 시 `compareOptions`가 올바르게 반영되는지
* 직원 카드에서 담당자 지정/해제 버튼 클릭 시 단일 항목만 토글되는지
* `CompanyMemberList` 레이아웃과 버튼 위치가 디자인 가이드에 부합하는지

## 🔁 테스트 결과

* **수동 테스트**: 프로젝트 정보 수정 → 저장, 단계 추가/순서 변경 → API 호출 확인
* **수동 테스트**: 직원 추가/삭제, 담당자 지정/해제 기능 정상 작동
* **빌드 및 CI**: 모든 유닛/통합 테스트 통과

## 🔗 연관된 이슈

* #417 

## 📑 레퍼런스

* 없음
