### PR TITLE
[refactor] 프로젝트 저장 payload 개선 및 단계·매니저 편집 로직 개선 (#417)

### DIFF
--- a/src/features/project/home/components/ProjectStepManager/ProjectStepManager.jsx
+++ b/src/features/project/home/components/ProjectStepManager/ProjectStepManager.jsx
@@ -103,19 +103,26 @@ export default function ProjectStepManager({
     const updated = orderedSteps.map((s, idx) => {
       const isTarget = s.projectStepId === editingStep.projectStepId;
       const updatedTitle = isTarget ? editingStep.title.trim() : s.title;
+
+      // 기존 isEdit 값을 기억해 두세요
+      const wasEdited = s.isEdit || false;
+
       return {
         ...s,
         title: updatedTitle,
         orderNumber: idx + 1,
-        isEdit: s.isNew ? false : isTarget && s.title !== updatedTitle,
+        // 새로 편집됐거나 이전에 편집된 적이 있으면 true
+        isEdit: s.isNew
+          ? false
+          : (isTarget && s.title !== updatedTitle) || wasEdited,
         isNew: s.isNew,
       };
     });
+
     setOrderedSteps(updated);
     setSteps(updated);
     setIsEditDialogOpen(false);
   };
-
   const handleConfirmAddStep = () => {
     const nextOrder = orderedSteps.length + 1;
     const newStep = {

--- a/src/features/project/home/hooks/useProjectForm.js
+++ b/src/features/project/home/hooks/useProjectForm.js
@@ -233,8 +233,7 @@ export default function useProjectForm(projectId) {
       project.detail !== values.detail ||
       dayjs(project.startAt).format("YYYY-MM-DD") !== values.startAt ||
       dayjs(project.endAt).format("YYYY-MM-DD") !== values.endAt ||
-      project.projectAmount !== values.projectAmount ||
-      project.step !== values.step;
+      project.projectAmount !== values.projectAmount;
 
     const devChanged = devAssigned.some((emp) => {
       const init = initialDevAssigned.find((i) => i.memberId === emp.memberId);
@@ -315,6 +314,7 @@ export default function useProjectForm(projectId) {
         ...(values.endAt && { endAt: `${values.endAt}T18:00:00` }),
         projectAmount:
           values.projectAmount === "" ? null : Number(values.projectAmount),
+        deleted: false,
       };
 
       // 2) 실제 프로젝트 필드 변경 여부만 체크
@@ -325,7 +325,7 @@ export default function useProjectForm(projectId) {
           values.startAt ||
         (project.endAt ? dayjs(project.endAt).format("YYYY-MM-DD") : "") !==
           values.endAt ||
-        project.projectAmount !== payload.projectAmount ||
+        project.projectAmount !== payload.projectAmount;
 
       // 3) 변경이 있을 때만 API 호출
       if (hasFieldChanges) {


### PR DESCRIPTION
## 📌 개요

* 프로젝트 저장 API 요청 시 `deleted` 필드 누락으로 발생하던 null 예외를 방지하도록 payload에 기본값 추가
* 단계 편집 후 `isEdit` 플래그가 유지되도록 로직 개선
* 매니저 토글 변경을 초기 스냅샷(`initialDevAssigned`/`initialClientAssigned`)과 비교하여 처리하는 로직으로 리팩터링

## 🛠️ 변경 사항

* **프로젝트 저장**

  * `payload`에 `deleted: false` 기본값 추가
  * `isEdited` 계산에서 `step` 비교 항목 제거
* **단계 편집 로직**

  * `handleDialogConfirm` 내 `isEdit` 값을 기존 `wasEdited` 플래그와 OR 연산하여 한 번 편집된 단계는 계속 강조
* **매니저 변경 로직**

  * `originalIsManager` 대신 `initialDevAssigned`/`initialClientAssigned`에서 초기 `isManager` 값을 찾아 비교
  * 변경된 매니저만 `updateProjectManager` API 호출
* 기타: 불필요 파일 삭제 및 `console.log` 모두 제거

## ✅ 주요 체크 포인트

* [ ] 프로젝트 수정 API 호출 시 더 이상 `deleted` 관련 500 에러가 발생하지 않는가
* [ ] 단계 편집 후 여러 단계를 연속으로 편집해도 각각 `isEdit` 강조 표시가 유지되는가
* [ ] 매니저 토글 후 저장 시, 백엔드에 올바른 멤버별 매니저 변경 요청이 발생하는가
* [ ] 전체 기능(프로젝트 상세, 단계 관리, 직원 관리 등)이 정상 동작하는가

## 🔁 테스트 결과

1. **프로젝트 수정**

   * 필드만 변경 없이 저장 클릭 → HTTP 500 에러 발생 없이 정상 응답
2. **단계 편집**

   * 단계 이름 수정 후 확인 → 해당 단계와 이전에 수정했던 단계 모두 강조 유지 확인
3. **매니저 토글**

   * 개발사·고객사 직원 중 매니저 토글 후 저장 → 네트워크 탭에서 변경된 멤버만 `/updateProjectManager` 호출 확인
4. **회귀 테스트**

   * 프로젝트 상세 페이지 진입, 단계 관리 기능, 직원 관리 기능 전반 테스트 완료

## 🔗 연관된 이슈

* `- #417`

## 📑 레퍼런스

* 없음
