### PR TITLE
[refactor] 프로젝트 저장 로직 비동기 개선 및 직원 선택 Autocomplete 리팩토링 (#417)

### DIFF
--- a/src/features/project/home/components/ProjectStepManager/ProjectStepManager.jsx
+++ b/src/features/project/home/components/ProjectStepManager/ProjectStepManager.jsx
@@ -103,19 +103,26 @@ export default function ProjectStepManager({
     const updated = orderedSteps.map((s, idx) => {
       const isTarget = s.projectStepId === editingStep.projectStepId;
       const updatedTitle = isTarget ? editingStep.title.trim() : s.title;
+
+      // 기존 isEdit 값을 기억해 두세요
+      const wasEdited = s.isEdit || false;
+
       return {
         ...s,
         title: updatedTitle,
         orderNumber: idx + 1,
-        isEdit: s.isNew ? false : isTarget && s.title !== updatedTitle,
+        // 새로 편집됐거나 이전에 편집된 적이 있으면 true
+        isEdit: s.isNew
+          ? false
+          : (isTarget && s.title !== updatedTitle) || wasEdited,
         isNew: s.isNew,
       };
     });
+
     setOrderedSteps(updated);
     setSteps(updated);
     setIsEditDialogOpen(false);
   };
-
   const handleConfirmAddStep = () => {
     const nextOrder = orderedSteps.length + 1;
     const newStep = {

--- a/src/features/project/home/hooks/useProjectForm.js
+++ b/src/features/project/home/hooks/useProjectForm.js
@@ -233,8 +233,7 @@ export default function useProjectForm(projectId) {
       project.detail !== values.detail ||
       dayjs(project.startAt).format("YYYY-MM-DD") !== values.startAt ||
       dayjs(project.endAt).format("YYYY-MM-DD") !== values.endAt ||
-      project.projectAmount !== values.projectAmount ||
-      project.step !== values.step;
+      project.projectAmount !== values.projectAmount;
 
     const devChanged = devAssigned.some((emp) => {
       const init = initialDevAssigned.find((i) => i.memberId === emp.memberId);
@@ -315,6 +314,7 @@ export default function useProjectForm(projectId) {
         ...(values.endAt && { endAt: `${values.endAt}T18:00:00` }),
         projectAmount:
           values.projectAmount === "" ? null : Number(values.projectAmount),
+        deleted: false,
       };
 
       // 2) 실제 프로젝트 필드 변경 여부만 체크
@@ -325,7 +325,7 @@ export default function useProjectForm(projectId) {
           values.startAt ||
         (project.endAt ? dayjs(project.endAt).format("YYYY-MM-DD") : "") !==
           values.endAt ||
-        project.projectAmount !== payload.projectAmount ||
+        project.projectAmount !== payload.projectAmount;
 
       // 3) 변경이 있을 때만 API 호출
       if (hasFieldChanges) {


### PR DESCRIPTION
## 📌 개요

* `save` 함수의 비동기 처리 방식을 개선하고, 자동 새로고침 시점을 조정해 모든 API 호출이 완료된 뒤 페이지가 리로드되도록 변경했습니다.
* `CompanyMemberSectionContent` 컴포넌트의 `Autocomplete`를 리팩토링하고, `memberName` 기반 검색 기능을 추가해 사용자 경험을 향상시켰습니다.

## 🛠️ 변경 사항

* **save 함수 비동기 로직 개선**

  * `fetchAllMembers` 헬퍼 추가: `getCompanyMembersByCompanyId`를 페이지 단위로 반복 호출해 전체 직원 목록을 가져오도록 구현
  * 직원 추가/삭제 로직을 `Promise` 배열로 묶고 `Promise.all`로 완전 대기
  * 매니저 변경 처리 로직도 `unwrap()` 후 `Promise.all`로 병렬 대기
  * `finally` 블록에 `window.location.reload()`를 이동시켜, 성공·실패 관계없이 모든 비동기 작업 완료 후 새로고침 보장

* **CompanyMemberSectionContent Autocomplete 리팩토링**

  * `useDispatch`, `useParams` 제거로 불필요 의존성 정리
  * `assigned` → `checkedList` 계산 로직 분리로 가독성 향상
  * `onInputChange`에서 `reason === "input"` 검사 추가
  * `filterOptions`를 이용해 `memberName` 기준 검색 기능 구현

## ✅ 주요 체크 포인트

* [ ] `fetchAllMembers`의 페이지 크기(현재 10개) 및 종료 조건이 실제 API 형식과 일치하는지
* [ ] `Promise.all`로 묶은 추가/삭제/매니저 변경 호출이 모두 정상 완료되는지
* [ ] Autocomplete에서 입력값에 따른 필터링이 기대한 대로 동작하는지
* [ ] 기존 직원 추가·삭제, 매니저 토글 기능에 사이드 이펙트는 없는지

## 🔁 테스트 결과

* 대용량 직원 데이터(3페이지 이상)인 경우에도 `save` 호출 시 전체 목록이 잘 조회됨을 확인
* `isNew`/`isDelete` 조건에 따른 추가·삭제 API 호출이 모두 성공 후 페이지가 새로고침됨을 검증
* 검색창에 이름 일부 입력 시 해당 항목만 필터링되고, 체크박스 선택/해제 시 `CompanyMemberList`가 올바르게 업데이트됨을 확인

## 🔗 연관된 이슈

* #417 

## 📑 레퍼런스

* 없음