### PR TITLE
[refactor] 프로젝트 저장 로직 리팩터링 및 오류 알림 추가 (#417)

### DIFF
--- a/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
+++ b/src/features/project/home/components/ProjectBasicInfoSectionContent.jsx
@@ -11,7 +11,6 @@ import { CalendarTodayRounded } from "@mui/icons-material";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import dayjs from "dayjs";
 import { useParams } from "react-router-dom";
-import { updateProjectStatus } from "@/api/project";
 import { STATUS_OPTIONS, getStatusLabel } from "@/utils/statusMaps";
 import { useSelector } from "react-redux";
 
@@ -27,16 +26,15 @@ export default function ProjectBasicInfoSectionContent({
   setPeriodEnd,
   projectAmount,
   setProjectAmount,
-  projectStep,
-  setProjectStep,
   project,
+  projectStatus,
+  setProjectStatus,
 }) {
   const [statusLoading, setStatusLoading] = React.useState(false);
   const [statusError, setStatusError] = React.useState("");
   const [amountError, setAmountError] = React.useState("");
-  const { id: projectId } = useParams();
   const userRole = useSelector((state) => state.auth.user?.role);
-  const canEditStep = [
+  const canEditStatus = [
     "ROLE_SYSTEM_ADMIN",
     "ROLE_DEV_ADMIN",
     "ROLE_CLIENT_ADMIN",
@@ -123,25 +121,13 @@ export default function ProjectBasicInfoSectionContent({
           )}
         </Grid>
 
-        {canEditStep && (
+        {canEditStatus && (
           <Grid item xs={12} sm={12}>
             <TextField
               select
               label="프로젝트 상태"
-              value={projectStep}
-              onChange={async (e) => {
-                const newStatus = e.target.value;
-                setStatusLoading(true);
-                setStatusError("");
-                try {
-                  await updateProjectStatus(projectId, newStatus);
-                  setProjectStep(newStatus);
-                } catch (err) {
-                  setStatusError("상태 변경에 실패했습니다.");
-                } finally {
-                  setStatusLoading(false);
-                }
-              }}
+              value={projectStatus}
+              onChange={(e) => setProjectStatus(e.target.value)}
               fullWidth
               sx={{ minWidth: 100 }}
               required

--- a/src/features/project/home/hooks/useProjectDetailSections.jsx
+++ b/src/features/project/home/hooks/useProjectDetailSections.jsx
@@ -45,8 +45,8 @@ export default function useProjectDetailSections(
           setPeriodEnd={(val) => setField("endAt", val)}
           projectAmount={values.projectAmount}
           setProjectAmount={(val) => setField("projectAmount", val)}
-          projectStep={values.step}
-          setProjectStep={(val) => setField("step", val)}
+          projectStatus={values.status}
+          setProjectStatus={(val) => setField("status", val)}
         />
       ),
     },

--- a/src/features/project/home/pages/ProjectDetailPage.jsx
+++ b/src/features/project/home/pages/ProjectDetailPage.jsx
@@ -8,6 +8,8 @@ import Section from "@/components/layouts/section/Section";
 import CustomButton from "@/components/common/customButton/CustomButton";
 import useProjectForm from "../hooks/useProjectForm";
 import useProjectDetailSections from "../hooks/useProjectDetailSections";
+import LoadingScreen from "@/components/common/loadingScreen/LoadingScreen";
+import AlertMessage from "@/components/common/alertMessage/AlertMessage";
 
 export default function ProjectDetailPage() {
   const { id } = useParams();
@@ -22,6 +24,9 @@ export default function ProjectDetailPage() {
     isEdited,
     reset,
     save,
+    saving,
+    alertInfo,
+    setAlertInfo,
     setStepEdited,
     setStepSaveFn,
     steps,
@@ -52,16 +57,6 @@ export default function ProjectDetailPage() {
     setDevAssigned,
     setClientAssigned
   );
-
-  if (!id || loading || !project) {
-    return (
-      <PageWrapper>
-        <Box display="flex" justifyContent="center" alignItems="center" mt={10}>
-          <CircularProgress />
-        </Box>
-      </PageWrapper>
-    );
-  }
 
   return (
     <PageWrapper>
@@ -119,6 +114,12 @@ export default function ProjectDetailPage() {
           </CustomButton>
         </Stack>
       )}
+      <AlertMessage
+        open={alertInfo.open}
+        onClose={() => setAlertInfo({ ...alertInfo, open: false })}
+        message={alertInfo.message}
+        severity={alertInfo.severity}
+      />
     </PageWrapper>
   );
 }

--- a/src/features/project/slices/projectMemberSlice.js
+++ b/src/features/project/slices/projectMemberSlice.js
@@ -5,6 +5,7 @@ import {
   addProjectMember,
   deleteProjectMember,
   getCompanyMembersInProject,
+  updateProjectManager as apiUpdateProjectManager,
 } from "@/api/projectMember";
 
 export const fetchProjectMemberList = createAsyncThunk(
@@ -49,6 +50,18 @@ export const removeMemberFromProject = createAsyncThunk(
     try {
       const response = await deleteProjectMember(projectId, memberId);
       return response.data.data; // ProjectMemberDeleteWebResponse
+    } catch (err) {
+      return rejectWithValue(err.response?.data || err.message);
+    }
+  }
+);
+
+export const updateProjectManager = createAsyncThunk(
+  "projectMember/updateManager",
+  async ({ projectId, memberId }, { rejectWithValue }) => {
+    try {
+      await apiUpdateProjectManager({ projectId, memberId });
+      return { memberId };
     } catch (err) {
       return rejectWithValue(err.response?.data || err.message);
     }
@@ -118,6 +131,18 @@ const projectMemberSlice = createSlice({
         state.list = state.list.filter((m) => m.id !== action.payload.memberId);
       })
       .addCase(removeMemberFromProject.rejected, (state, action) => {
+        state.loading = false;
+        state.error = action.payload;
+      })
+      .addCase(updateProjectManager.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(updateProjectManager.fulfilled, (state, action) => {
+        state.loading = false;
+        // 필요에 따라 companyMembers나 list 안에서 해당 memberId의 isManager 값을 갱신할 수 있습니다.
+      })
+      .addCase(updateProjectManager.rejected, (state, action) => {
         state.loading = false;
         state.error = action.payload;
       });


### PR DESCRIPTION
## 📌 개요

* `useProjectForm` 훅의 상태 변경 API 호출 타이밍을 즉시 호출에서 “저장” 버튼 클릭 시점으로 이동
* 저장 중 오류 발생 시 사용자에게 `AlertMessage` 컴포넌트로 알림창을 띄우도록 추가
* `projectMemberSlice`에 매니저 권한 변경용 `updateProjectManager` Thunk와 리듀서를 구현

## 🛠️ 변경 사항

* **useProjectForm 훅**

  * `onChange`에서 즉시 호출하던 `updateProjectStatus`를 제거하고, `save()` 내부로 모두 통합
  * `save()` 함수에서 API 호출 성공 여부에 따라 로딩 화면 유지 또는 해제 로직 적용
* **ProjectDetailPage 컴포넌트**

  * 저장 실패 시 `AlertMessage`를 통해 오류 알림 표시하도록 추가
* **projectMemberSlice**

  * `updateProjectManager` createAsyncThunk 정의
  * `.pending`/`.fulfilled`/`.rejected` extraReducers 등록

## ✅ 주요 체크 포인트

* [ ] 상태 변경(`status`) 시점이 “저장” 버튼 클릭 이후로 올바르게 변경되었는지
* [ ] API 오류 발생 시 `AlertMessage`가 정상적으로 표시되는지
* [ ] 매니저 권한 변경 요청 시 Redux Thunk가 제대로 호출되고, `state.loading`/`state.error`가 올바르게 업데이트되는지

## 🔁 테스트 결과

* **기능 테스트**

  1. 프로젝트 상태를 변경 → 즉시 API 호출 없이 `save` 버튼 활성화
  2. `save` 클릭 → 저장 로딩 화면 표시 → API 성공 후 페이지 리로드
  3. API 에러 강제 발생 → 로딩 해제 후 상단 오류 알림 표시
* **매니저 권한 변경**

  * 개발사/고객사 멤버 리스트에서 매니저 토글 후 저장 → 네트워크 탭에서 `updateProjectManager` 호출 확인

## 🔗 연관된 이슈

* #417 

## 📑 레퍼런스

* 없음.
