### PR TITLE
[feat] 게시글의 댓글 수정 기능 추가(#450)

### DIFF
--- a/src/features/project/post/components/CommentSection.jsx
+++ b/src/features/project/post/components/CommentSection.jsx
@@ -8,20 +8,22 @@ import {
   IconButton,
 } from "@mui/material";
 import ReplyIcon from "@mui/icons-material/Reply";
+import EditIcon from "@mui/icons-material/Edit";
 import CommentInput from "./CommentInput";
 import CustomButton from "@/components/common/customButton/CustomButton";
 
 // 재귀적으로 리뷰를 렌더링하는 컴포넌트
 function CommentItem({ review, level = 0, postId, onReply }) {
   const [replying, setReplying] = useState(false);
+  const [editing, setEditing] = useState(false);
 
   return (
-    <Box sx={{ mt: 2, ml: level * 4 }}>
+    <Box sx={{ mt: 2, ml: level * 4, position: "relative" }}>
       <Stack direction="row" spacing={1} alignItems="flex-start">
         <Avatar sx={{ width: 34, height: 34, fontSize: 14 }}>
           {review.companyName?.[0] || "?"}
         </Avatar>
-        <Box sx={{ flex: 1, position: "relative" }}>
+        <Box sx={{ flex: 1 }}>
           <Stack spacing={1}>
             <Stack direction="row" spacing={1} alignItems="baseline">
               <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
@@ -39,16 +41,45 @@ function CommentItem({ review, level = 0, postId, onReply }) {
               {review.createdAt}
             </Typography>
           </Stack>
-          <Typography variant="body2" sx={{ mt: 2, whiteSpace: "pre-wrap" }}>
-            {review.comment}
-          </Typography>
 
-          {/* 답글 버튼을 오른쪽 끝으로 */}
-          {level === 0 && (
+          {/* 댓글 본문 혹은 수정 입력폼 */}
+          {editing ? (
+            <Box sx={{ mt: 2 }}>
+              <CommentInput
+                postId={postId}
+                editReviewId={review.reviewId}
+                initialText={review.comment}
+                onCancel={() => setEditing(false)}
+              />
+            </Box>
+          ) : (
+            <Typography variant="body2" sx={{ mt: 2, whiteSpace: "pre-wrap" }}>
+              {review.comment}
+            </Typography>
+          )}
+        </Box>
+
+        {/* 답글/수정 버튼 모음 */}
+        <Box
+          sx={{
+            position: "absolute",
+            top: 0,
+            right: 0,
+            display: "flex",
+            alignItems: "center",
+            gap: 1,
+            p: 0.5,
+          }}
+        >
+          {!editing && (
+            <IconButton size="small" onClick={() => setEditing(true)}>
+              <EditIcon fontSize="small" />
+            </IconButton>
+          )}
+          {level === 0 && !editing && (
             <IconButton
               size="small"
               onClick={() => setReplying((prev) => !prev)}
-              sx={{ position: "absolute", top: 0, right: 0 }}
             >
               <ReplyIcon fontSize="small" />
             </IconButton>
@@ -57,7 +88,7 @@ function CommentItem({ review, level = 0, postId, onReply }) {
       </Stack>
 
       {/* 대댓글 입력창 */}
-      {replying && (
+      {replying && !editing && (
         <Box sx={{ ml: (level + 1) * 4, mt: 2 }}>
           <CommentInput
             postId={postId}
@@ -70,8 +101,8 @@ function CommentItem({ review, level = 0, postId, onReply }) {
         </Box>
       )}
 
-      {/* 자식 리뷰 렌더링 */}
-      {review.childReviews && review.childReviews.length > 0 && (
+      {/* 자식 리뷰(대댓글) 렌더링 */}
+      {review.childReviews?.length > 0 && (
         <Box sx={{ mt: 1 }}>
           {review.childReviews.map((child) => (
             <CommentItem
@@ -101,8 +132,10 @@ export default function CommentSection({
 }) {
   return (
     <Box sx={{ mt: 3 }}>
+      {/* 신규 댓글 입력 */}
       <CommentInput postId={postId} onSubmit={(text) => onSubmit(text)} />
 
+      {/* 댓글 목록 */}
       {comments.map((review) => (
         <CommentItem
           key={review.reviewId}
@@ -112,6 +145,7 @@ export default function CommentSection({
         />
       ))}
 
+      {/* 더보기 버튼 */}
       {hasMore && (
         <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
           <CustomButton


### PR DESCRIPTION
## 📌 개요

* 사용자가 작성한 댓글(리뷰)을 수정할 수 있는 기능 추가

  * 기존 댓글 등록 로직에 “수정 모드” 분기 처리를 도입하고, 수정 전용 입력폼 및 버튼 UI를 구현

## 🛠️ 변경 사항

* `editReviewId` 존재 여부에 따라 `addReview`와 `updateReview` 액션을 분기 처리하도록 로직 추가
* 댓글 영역에서 ✏️ 버튼을 눌러 수정 모드로 전환하는 `editing` 상태 및 `EditIcon` 버튼 추가
* 수정 모드일 때 기존 텍스트 대신 `CommentInput` 컴포넌트를 렌더링하도록 조건부 렌더링 적용
* 수정 완료·취소 시 입력창 초기화 및 `onCancel` 핸들러 연결
* 수정 완료 후 `fetchReviews({ postId, page: 1 })` 호출로 최신 댓글 목록을 1페이지로 갱신

## ✅ 주요 체크 포인트

* [ ] 댓글 수정 로직이 정상적으로 분기 처리되는지 (`editReviewId` 유무)
* [ ] 수정 모드 진입·취소 시 UI 및 상태가 올바르게 초기화되는지
* [ ] 수정 완료 후 댓글 리스트가 1페이지로 깔끔하게 갱신되는지
* [ ] 기존 댓글 등록, 대댓글 등록 기능에 영향이 없는지

## 🔁 테스트 결과

* ✏️ 버튼 클릭 → 입력폼으로 전환, 텍스트 수정 후 저장 클릭 시 API 요청 정상 호출됨
* 수정 완료 시 `setText("")` 및 `onCancel()` 호출로 입력창이 초기화되고, 댓글 목록이 1페이지로 리프레시됨
* 취소 버튼 클릭 시 기존 댓글 표시로 돌아오며 입력 내용이 남지 않음
* 댓글 등록·대댓글 기능도 의도대로 동작함을 확인

## 🔗 연관된 이슈

* #450 

## 📑 레퍼런스

* 없음
