### PR TITLE
[feat] : 회사 로고 이미지 다운로드/업로드 버그 수정

### DIFF
--- a/src/api/company.js
+++ b/src/api/company.js
@@ -33,6 +33,19 @@ export function getCompanyImageUploadUrl(companyId, fileName) {
 }
 
 /**
+ * 회사 이미지 다운로드 URL 발급
+ * GET /api/companies/images/download-url
+ * 
+ * @param {string} companyId - 회사 UUID
+ * @returns {Promise<import("axios").AxiosResponse>} ApiResponse<{downloadUrl: string, expiration: string}>
+ */
+export function getCompanyImageDownloadUrl(companyId) {
+  return api.get(`/api/companies/images/download-url`, {
+    params: { companyId }
+  });
+}
+
+/**
  * 회사 이미지 삭제
  * DELETE /api/companies/images/{companyId}
  * 

--- a/src/features/company/components/CompanyImageUploadSection.jsx
+++ b/src/features/company/components/CompanyImageUploadSection.jsx
@@ -26,7 +26,7 @@ export default function CompanyImageUploadSection({
     <Box>
       <Stack direction="row" alignItems="center" spacing={1}>
         <Typography variant="subtitle1" fontWeight={600}>
-          4. 로고 이미지
+          4. 회사 로고
         </Typography>
         <Tooltip title="회사 로고 이미지를 업로드하세요. (JPG, PNG, GIF, 최대 5MB)">
           <InfoOutlined fontSize="small" color="action" />
@@ -108,7 +108,7 @@ export default function CompanyImageUploadSection({
               >
                 <CloudUpload sx={{ fontSize: 32, mb: 1, opacity: 0.5 }} />
                 <Typography variant="caption" sx={{ fontSize: "0.7rem" }}>
-                  로고 이미지
+                  회사 로고
                 </Typography>
               </Box>
             )}

--- a/src/features/company/pages/CompanyDetailPage.jsx
+++ b/src/features/company/pages/CompanyDetailPage.jsx
@@ -13,7 +13,7 @@ import {
   CircularProgress,
   Avatar,
 } from "@mui/material";
-import { InfoOutlined, Close as CloseIcon } from "@mui/icons-material";
+import { InfoOutlined, Close as CloseIcon, CloudUpload } from "@mui/icons-material";
 import PageWrapper from "@/components/layouts/pageWrapper/PageWrapper";
 import PageHeader from "@/components/layouts/pageHeader/PageHeader";
 import {
@@ -21,6 +21,7 @@ import {
   deleteCompany,
 } from "@/features/company/companySlice";
 import { getCompanyMembersByCompanyId } from "@/api/member";
+import { getCompanyImageDownloadUrl } from "@/api/company";
 import { useTheme } from "@mui/material/styles";
 import CustomButton from "@/components/common/customButton/CustomButton";
 import CreateRoundedIcon from "@mui/icons-material/CreateRounded";
@@ -42,10 +43,25 @@ export default function CompanyDetailPage() {
   const [page, setPage] = useState(1);
   const [loadingMembers, setLoadingMembers] = useState(false);
   const [searchText, setSearchText] = useState("");
+  const [companyImageUrl, setCompanyImageUrl] = useState(null);
 
   useEffect(() => {
     dispatch(fetchCompanyById(id));
   }, [dispatch, id]);
+
+  // 회사 로고 이미지 다운로드 URL 요청
+  useEffect(() => {
+    if (company?.logoImagePath && company?.companyId) {
+      getCompanyImageDownloadUrl(company.companyId)
+        .then((response) => {
+          const downloadUrl = response.data.data.downloadUrl;
+          setCompanyImageUrl(downloadUrl);
+        })
+        .catch((error) => {
+          console.error('회사 이미지 다운로드 URL 발급 실패:', error);
+        });
+    }
+  }, [company?.logoImagePath, company?.companyId]);
 
   useEffect(() => {
     if (!company?.companyId) return;
@@ -245,6 +261,83 @@ export default function CompanyDetailPage() {
                   onChange={(_, value) => setPage(value)}
                   size="small"
                 />
+              </Box>
+            </Box>
+
+            {/* 4. 회사 로고 */}
+            <Box>
+              <Stack direction="row" alignItems="center" spacing={1}>
+                <Typography variant="subtitle1" fontWeight={600}>
+                  4. 회사 로고
+                </Typography>
+                <Tooltip title="회사 로고 이미지입니다.">
+                  <InfoOutlined fontSize="small" color="action" />
+                </Tooltip>
+              </Stack>
+              <Divider sx={{ mt: 1, mb: 2 }} />
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 2,
+                }}
+              >
+                {/* 이미지 미리보기 또는 플레이스홀더 */}
+                <Box
+                  sx={{
+                    position: "relative",
+                    display: "inline-block",
+                    width: "120px",
+                    height: "120px",
+                    borderRadius: "50%",
+                    border: "3px solid",
+                    borderColor: companyImageUrl ? "primary.main" : "grey.300",
+                    overflow: "hidden",
+                    boxShadow: companyImageUrl
+                      ? "0 4px 12px rgba(0, 0, 0, 0.15)"
+                      : "0 2px 8px rgba(0, 0, 0, 0.1)",
+                    backgroundColor: "grey.50",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  {companyImageUrl ? (
+                    <img
+                      src={companyImageUrl}
+                      alt="회사 로고"
+                      style={{
+                        width: "100%",
+                        height: "100%",
+                        objectFit: "cover",
+                      }}
+                    />
+                  ) : (
+                    <Box
+                      sx={{
+                        display: "flex",
+                        flexDirection: "column",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        color: "text.secondary",
+                        textAlign: "center",
+                        p: 2,
+                      }}
+                    >
+                      <CloudUpload sx={{ fontSize: 32, mb: 1, opacity: 0.5 }} />
+                      <Typography variant="caption" sx={{ fontSize: "0.7rem" }}>
+                        회사 로고
+                      </Typography>
+                    </Box>
+                  )}
+                </Box>
+
+                {/* 빈 공간 (버튼 자리) */}
+                <Box>
+                  <Typography variant="body2" color="text.secondary">
+                    회사 로고 이미지가 표시됩니다.
+                  </Typography>
+                </Box>
               </Box>
             </Box>
           </Stack>

--- a/src/layouts/Sidebar.jsx
+++ b/src/layouts/Sidebar.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useDispatch, useSelector } from "react-redux";
 import {
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import NotificationsRoundedIcon from "@mui/icons-material/NotificationsRounded";
+import { getCompanyImageDownloadUrl } from "@/api/company";
 
 import {
   SidebarRoot,
@@ -39,7 +40,24 @@ export default function Sidebar({
   const memberName = useSelector((state) => state.auth.user?.name);
   const memberRole = useSelector((state) => state.auth.user?.role);
   const logoImagePath = useSelector((state) => state.auth.company?.logoImagePath);
+  const companyId = useSelector((state) => state.auth.company?.id);
   const currentPath = location.pathname;
+  
+  const [companyImageUrl, setCompanyImageUrl] = useState(null);
+
+  // 회사 로고 이미지 다운로드 URL 요청
+  useEffect(() => {
+    if (logoImagePath && companyId) {
+      getCompanyImageDownloadUrl(companyId)
+        .then((response) => {
+          const downloadUrl = response.data.data.downloadUrl;
+          setCompanyImageUrl(downloadUrl);
+        })
+        .catch((error) => {
+          console.error('회사 이미지 다운로드 URL 발급 실패:', error);
+        });
+    }
+  }, [logoImagePath, companyId]);
 
   const filteredNavItems = navItems.filter(
     (item) => item.roles && item.roles.includes(memberRole)
@@ -65,7 +83,7 @@ export default function Sidebar({
     <SidebarRoot>
       <ProfileSection>
         <Avatar 
-          src={logoImagePath || "/toss_logo.png"} 
+          src={companyImageUrl || "/toss_logo.png"} 
         />
         <Box
           sx={{

--- a/src/utils/uploadCompanyImage.js
+++ b/src/utils/uploadCompanyImage.js
@@ -30,9 +30,8 @@ export async function uploadCompanyImage(file, companyId, onProgress) {
       throw new Error(`업로드 실패: ${uploadResponse.status} - ${uploadResponse.statusText}`);
     }
 
-    // 3단계: 업로드된 이미지 URL 반환 (presigned URL에서 실제 URL 추출)
-    const uploadedUrl = uploadUrl.split('?')[0];
-    return uploadedUrl;
+    // 3단계: 파일명만 반환
+    return file.name;
 
   } catch (error) {
     throw new Error('이미지 업로드에 실패했습니다.');


### PR DESCRIPTION
## 📌 개요

- 회사 로고 이미지 다운로드/업로드 버그 수정

## 🛠️ 변경 사항

- **회사 생성 시 이미지 업로드 수정**
  - `uploadCompanyImage.js`: S3 URL 대신 파일명만 반환하도록 수정
  
- **회사 수정 페이지 기존 이미지 미리보기 기능 추가**
  - `getCompanyImageDownloadUrl` API 함수 추가
  - `logoImagePath`가 있을 때 다운로드 URL 발급 요청
  - 기존 이미지 미리보기 표시 및 삭제 시 미리보기 제거
  
- **사이드바 회사 로고 표시 기능 구현**
  - 로그인 후 회사 로고 이미지를 사이드바에 표시
  - `logoImagePath`가 있으면 다운로드 URL 요청하여 이미지 표시
  
- **회사 상세 보기 페이지 로고 섹션 추가**
  - 4번 항목으로 회사 로고 섹션 추가
  - 수정 페이지와 동일한 디자인 적용 (120px 원형, gap 레이아웃)
  - 이미지 다운로드 URL 요청 및 미리보기 표시
  
- **UI/UX 개선**
  - "로고 이미지" → "회사 로고" 텍스트 통일
  - 이미지 없을 때 CloudUpload 아이콘과 안내 텍스트 표시

## ✅ 주요 체크 포인트

- [x] **API 호출 구조**: `GET /api/companies/images/download-url?companyId=uuid` 요청이 올바르게 이루어지는지 확인
- [x] **이미지 미리보기 로직**: 기존 이미지와 새로 선택한 이미지 간의 상태 전환이 정상적으로 작동하는지 확인

## 🔁 테스트 결과

- **회사 생성**: 이미지 업로드 후 `logoImagePath`에 파일명만 저장되는 것 확인
- **회사 수정**: 기존 이미지 미리보기 표시 및 새 이미지 선택/삭제 기능 정상 작동 확인
- **사이드바**: 로그인 후 회사 로고가 정상적으로 표시되는 것 확인  
- **상세 보기**: 회사 상세 페이지에서 로고 이미지가 올바르게 표시되는 것 확인
- **반응형**: 수정 페이지와 상세 페이지의 로고 섹션 디자인 일관성 확인

## 🔗 연관된 이슈
- #454 