### PR TITLE
[build] : 게시글 수정시 이미지 업로드 기능 추가

### DIFF
--- a/src/features/company/pages/CompanyFormPage.jsx
+++ b/src/features/company/pages/CompanyFormPage.jsx
@@ -243,7 +243,12 @@ export default function CompanyFormPage() {
     setExistingImageUrl(null);
     
     // 파일 검증 및 미리보기 설정
-    await originalHandleImageSelect(event);
+    const isValid = await originalHandleImageSelect(event);
+    
+    // 검증에 실패하면 업로드 중단
+    if (!isValid) {
+      return;
+    }
     
     // 수정 모드에서는 바로 업로드 (이미 회사 ID가 있음)
     if (isEdit && id) {

--- a/src/features/project/post/components/FileAttachmentViewer.jsx
+++ b/src/features/project/post/components/FileAttachmentViewer.jsx
@@ -11,7 +11,6 @@ import ZoomInIcon from "@mui/icons-material/ZoomIn";
 import DownloadIcon from "@mui/icons-material/Download";
 import AlertMessage from "@/components/common/alertMessage/AlertMessage";
 import { getFileIcon } from "@/utils/getFileIcon";
-import { formatFileSize } from "@/utils/formatFileSize";
 
 export default function FileAttachmentViewer({
   attachments = [],
@@ -49,74 +48,79 @@ export default function FileAttachmentViewer({
       <Divider sx={{ mb: 3 }} />
 
       <Stack spacing={1}>
-        {attachments.map((file) => (
-          <Box
-            key={file.id}
-            sx={{
-              p: 2,
-              border: "1px solid",
-              borderColor: "grey.300",
-              borderRadius: 1,
-              bgcolor: "background.paper",
-              "&:hover": {
-                borderColor: "primary.main",
-                bgcolor: "grey.50",
-              },
-            }}
-          >
-            <Stack direction="row" alignItems="center" spacing={2}>
-              <Box
-                sx={{
-                  width: 40,
-                  height: 40,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  bgcolor: "grey.100",
-                  borderRadius: 1,
-                }}
-              >
-                {getFileIcon(file.fileName, file.fileType)}
-              </Box>
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Typography variant="body2" fontWeight={600} noWrap>
-                  {file.fileName}
-                </Typography>
-                <Typography variant="caption" color="text.secondary">
-                  {formatFileSize(file.fileSize)}
-                  {file.fileType && ` • ${file.fileType}`}
-                </Typography>
-              </Box>
-              <Stack direction="row" spacing={1}>
-                {file.isImage && file.imageUrl && onPreview && (
-                  <Tooltip title="미리보기">
-                    <IconButton size="small" onClick={() => onPreview(file)}>
-                      <ZoomInIcon />
-                    </IconButton>
-                  </Tooltip>
-                )}
-                {onDownload && (
-                  <Tooltip title="다운로드">
-                    <IconButton size="small" onClick={() => onDownload(file)}>
-                      <DownloadIcon />
-                    </IconButton>
-                  </Tooltip>
-                )}
-              </Stack>
-            </Stack>
+        {attachments.map((file) => {
+          // postAttachments 구조에 맞게 매핑
+          const fileData = {
+            id: file.postAttachmentId,
+            fileName: file.fileName,
+            fileSize: file.fileSize,
+            fileType: file.fileType,
+            isImage: file.fileType?.startsWith("image/"),
+          };
 
-            {file.error && (
-              <Box mt={1}>
-                <AlertMessage
-                  open={true}
-                  message={`파일 로드 실패: ${file.error}`}
-                  severity="error"
-                  onClose={() => {}}
-                />
-              </Box>
-            )}
-          </Box>
-        ))}
+          return (
+            <Box
+              key={file.postAttachmentId}
+              sx={{
+                p: 2,
+                border: "1px solid",
+                borderColor: "grey.300",
+                borderRadius: 1,
+                bgcolor: "background.paper",
+                "&:hover": {
+                  borderColor: "primary.main",
+                  bgcolor: "grey.50",
+                },
+              }}
+            >
+              <Stack direction="row" alignItems="center" spacing={2}>
+                <Box
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    bgcolor: "grey.100",
+                    borderRadius: 1,
+                  }}
+                >
+                  {getFileIcon(fileData.fileName, fileData.fileType)}
+                </Box>
+                                 <Box sx={{ flex: 1, minWidth: 0 }}>
+                   <Typography variant="body2" fontWeight={600} noWrap>
+                     {fileData.fileName}
+                   </Typography>
+                   {fileData.fileType && (
+                     <Typography variant="caption" color="text.secondary">
+                       {fileData.fileType}
+                     </Typography>
+                   )}
+                 </Box>
+                <Stack direction="row" spacing={1}>
+                  {onDownload && (
+                    <Tooltip title="다운로드">
+                      <IconButton size="small" onClick={() => onDownload(fileData)}>
+                        <DownloadIcon />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                </Stack>
+              </Stack>
+
+              {file.error && (
+                <Box mt={1}>
+                  <AlertMessage
+                    open={true}
+                    message={`파일 로드 실패: ${file.error}`}
+                    severity="error"
+                    onClose={() => {}}
+                  />
+                </Box>
+              )}
+            </Box>
+          );
+        })}
       </Stack>
 
       <AlertMessage

--- a/src/features/project/post/components/FileUploadSection.jsx
+++ b/src/features/project/post/components/FileUploadSection.jsx
@@ -1,67 +1,167 @@
 import React from "react";
-import { Box, Stack, Typography, Divider, Tooltip } from "@mui/material";
+import { Box, Stack, Typography, Divider, Tooltip, Button } from "@mui/material";
 import { InfoOutlined, CloudUpload } from "@mui/icons-material";
 import CustomButton from "@/components/common/customButton/CustomButton";
 import FileAttachmentCard from "./FileAttachmentCard";
+import { getFileIcon } from "@/utils/getFileIcon";
 
 export default function FileUploadSection({
   files,
+  existingAttachments = [],
+  deletedAttachmentIds = [],
   onSelect,
   onDelete,
   onRetry,
   onPreview,
+  onExistingDelete,
+  onExistingRestore,
+  title = "4. 파일 첨부",
+  isEditing = false,
 }) {
   return (
     <Box>
       <Stack direction="row" alignItems="center" spacing={1}>
         <Typography variant="subtitle1" fontWeight={600}>
-          4. 파일 첨부
+          {title}
         </Typography>
-        <Tooltip title="모든 파일 형식 첨부 가능합니다. (최대 5MB, 실행파일 제외)">
+        <Tooltip title={isEditing ? "기존 파일을 삭제하거나 새로운 파일을 추가할 수 있습니다." : "모든 파일 형식 첨부 가능합니다. (최대 5MB, 실행파일 제외)"}>
           <InfoOutlined fontSize="small" color="action" />
         </Tooltip>
       </Stack>
       <Divider sx={{ mt: 1, mb: 2 }} />
 
-      <Stack spacing={2}>
-        <input
-          type="file"
-          multiple
-          onChange={onSelect}
-          style={{ display: "none" }}
-          id="file-upload"
-          accept="*"
-        />
-        <label htmlFor="file-upload">
-          <CustomButton
-            kind="ghost"
-            component="span"
-            startIcon={<CloudUpload />}
-          >
-            파일 선택
-          </CustomButton>
-        </label>
-      </Stack>
-
-      {files.length > 0 && (
-        <Box sx={{ mt: 2 }}>
-          <Typography variant="subtitle2" fontWeight={600}>
-            첨부 파일 목록 ({files.length}개)
+      {/* 기존 첨부파일 목록 (편집 모드에서만) */}
+      {isEditing && existingAttachments.length > 0 && (
+        <Box sx={{ mb: 3 }}>
+          <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 1 }}>
+            기존 첨부파일 ({existingAttachments.length}개)
           </Typography>
-          <Divider sx={{ mt: 1, mb: 2 }} />
           <Stack spacing={1}>
-            {files.map((file) => (
-              <FileAttachmentCard
-                key={file.id}
-                file={file}
-                onPreview={onPreview}
-                onDelete={onDelete}
-                onRetry={onRetry}
-              />
-            ))}
+            {existingAttachments.map((attachment) => {
+              const isDeleted = deletedAttachmentIds.includes(attachment.postAttachmentId);
+              return (
+                <Box
+                  key={attachment.postAttachmentId}
+                  sx={{
+                    p: 2,
+                    border: "1px solid",
+                    borderColor: isDeleted ? 'error.main' : 'grey.300',
+                    borderRadius: 1,
+                    bgcolor: isDeleted ? 'error.50' : 'background.paper',
+                    opacity: isDeleted ? 0.6 : 1,
+                    "&:hover": !isDeleted ? {
+                      borderColor: "primary.main",
+                      bgcolor: "grey.50",
+                    } : {},
+                  }}
+                >
+                  <Stack direction="row" alignItems="center" spacing={2}>
+                    <Box
+                      sx={{
+                        width: 40,
+                        height: 40,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        bgcolor: "grey.100",
+                        borderRadius: 1,
+                      }}
+                    >
+                      {getFileIcon(attachment.fileName, attachment.fileType)}
+                    </Box>
+                    <Box sx={{ flex: 1, minWidth: 0 }}>
+                      <Typography 
+                        variant="body2" 
+                        fontWeight={600}
+                        noWrap
+                        sx={{ 
+                          textDecoration: isDeleted ? 'line-through' : 'none',
+                          color: isDeleted ? 'error.main' : 'text.primary'
+                        }}
+                      >
+                        {attachment.fileName}
+                      </Typography>
+                      {attachment.fileType && (
+                        <Typography variant="caption" color="text.secondary">
+                          {attachment.fileType}
+                        </Typography>
+                      )}
+                    </Box>
+                    <Box>
+                      {isDeleted ? (
+                        <Button
+                          size="small"
+                          color="primary"
+                          onClick={() => onExistingRestore?.(attachment.postAttachmentId)}
+                        >
+                          복원
+                        </Button>
+                      ) : (
+                        <Button
+                          size="small"
+                          color="error"
+                          onClick={() => onExistingDelete?.(attachment.postAttachmentId)}
+                        >
+                          삭제
+                        </Button>
+                      )}
+                    </Box>
+                  </Stack>
+                </Box>
+              );
+            })}
           </Stack>
         </Box>
       )}
+
+      {/* 새로운 파일 추가 섹션 */}
+      <Box>
+        {isEditing && (
+          <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 2 }}>
+            새 파일 추가
+          </Typography>
+        )}
+        
+        <Stack spacing={2}>
+          <input
+            type="file"
+            multiple
+            onChange={onSelect}
+            style={{ display: "none" }}
+            id="file-upload"
+            accept="*"
+          />
+          <label htmlFor="file-upload">
+            <CustomButton
+              kind="ghost"
+              component="span"
+              startIcon={<CloudUpload />}
+            >
+              파일 선택
+            </CustomButton>
+          </label>
+        </Stack>
+
+        {files.length > 0 && (
+          <Box sx={{ mt: 2 }}>
+            <Typography variant="subtitle2" fontWeight={600}>
+              {isEditing ? "선택된 새 파일" : "첨부 파일 목록"} ({files.length}개)
+            </Typography>
+            <Divider sx={{ mt: 1, mb: 2 }} />
+            <Stack spacing={1}>
+              {files.map((file) => (
+                <FileAttachmentCard
+                  key={file.id}
+                  file={file}
+                  onPreview={onPreview}
+                  onDelete={onDelete}
+                  onRetry={onRetry}
+                />
+              ))}
+            </Stack>
+          </Box>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/src/features/project/post/pages/PostDetailDrawer.jsx
+++ b/src/features/project/post/pages/PostDetailDrawer.jsx
@@ -30,7 +30,6 @@ import FileUploadSection from "../components/FileUploadSection";
 import { fetchReviews } from "../reviewSlice";
 import {
   deletePost,
-  fetchAttachmentImages,
   clearAttachmentImages,
   updatePostApproval,
   updatePost,
@@ -75,10 +74,7 @@ export default function PostDetailDrawer({
   const [newFiles, setNewFiles] = useState([]); // 새로 추가된 파일들
   const [deletedAttachmentIds, setDeletedAttachmentIds] = useState([]); // 삭제할 기존 첨부파일 ID들
 
-  // 첨부 이미지 뷰어 상태
-  const attachmentImages = useSelector((s) => s.post.attachmentImages || []);
-  const imagesLoading = useSelector((s) => s.post.imagesLoading);
-  const imagesError = useSelector((s) => s.post.imagesError);
+  // 첨부 이미지 뷰어 상태 (제거됨)
 
   // 파일 미리보기 모달
   const [previewModal, setPreviewModal] = useState({
@@ -103,9 +99,10 @@ export default function PostDetailDrawer({
     if (!open || !initialPost?.postId) return;
     dispatch(clearAttachmentImages());
     dispatch(fetchReviews({ postId: initialPost.postId, page: 1 }));
-    if (initialPost.postAttachments?.length) {
-      dispatch(fetchAttachmentImages(initialPost.postAttachments));
-    }
+    // 첨부파일 자동 다운로드 제거
+    // if (initialPost.postAttachments?.length) {
+    //   dispatch(fetchAttachmentImages(initialPost.postAttachments));
+    // }
     // 새로 열 때마다 Redux에서 상세 데이터도 다시 가져옵니다
     dispatch(fetchPostById(initialPost.postId));
   }, [open, initialPost, dispatch]);
@@ -195,10 +192,10 @@ export default function PostDetailDrawer({
       setDeletedAttachmentIds([]);
       await dispatch(fetchPostById(detail.postId)).unwrap();
       
-      // 첨부파일 이미지도 새로고침
-      if (detail.postAttachments?.length) {
-        dispatch(fetchAttachmentImages(detail.postAttachments));
-      }
+      // 첨부파일 자동 다운로드 제거
+      // if (detail.postAttachments?.length) {
+      //   dispatch(fetchAttachmentImages(detail.postAttachments));
+      // }
 
       setIsEditing(false);
     } catch {
@@ -501,9 +498,9 @@ export default function PostDetailDrawer({
                 </Box>
 
                 <FileAttachmentViewer
-                  attachments={attachmentImages}
-                  loading={imagesLoading}
-                  error={imagesError}
+                  attachments={detail.postAttachments || []}
+                  loading={false}
+                  error={null}
                   onPreview={handlePreviewOpen}
                   onDownload={handleDownload}
                 />

--- a/src/features/project/post/pages/PostDetailDrawer.jsx
+++ b/src/features/project/post/pages/PostDetailDrawer.jsx
@@ -15,8 +15,6 @@ import {
   Close as CloseIcon,
   Edit as EditIcon,
   Delete as DeleteIcon,
-  InfoOutlined,
-  CloudUpload,
 } from "@mui/icons-material";
 import { useTheme } from "@mui/material/styles";
 import { useDispatch, useSelector } from "react-redux";
@@ -375,84 +373,19 @@ export default function PostDetailDrawer({
                 />
 
                 {/* 파일 수정 섹션 */}
-                <Box>
-                  <Stack direction="row" alignItems="center" spacing={1}>
-                    <Typography variant="subtitle1" fontWeight={600}>
-                      파일 수정
-                    </Typography>
-                    <Tooltip title="기존 파일을 삭제하거나 새로운 파일을 추가할 수 있습니다.">
-                      <InfoOutlined fontSize="small" color="action" />
-                    </Tooltip>
-                  </Stack>
-                  <Divider sx={{ mt: 1, mb: 2 }} />
-
-                  {/* 기존 첨부파일 목록 */}
-                  {detail.postAttachments && detail.postAttachments.length > 0 && (
-                    <Box sx={{ mb: 3 }}>
-                      <Typography variant="subtitle2" fontWeight={600} sx={{ mb: 1 }}>
-                        기존 첨부파일
-                      </Typography>
-                      <Stack spacing={1}>
-                        {detail.postAttachments.map((attachment) => {
-                          const isDeleted = deletedAttachmentIds.includes(attachment.postAttachmentId);
-                          return (
-                            <Box
-                              key={attachment.postAttachmentId}
-                              sx={{
-                                p: 2,
-                                border: 1,
-                                borderColor: isDeleted ? 'error.main' : 'grey.300',
-                                borderRadius: 1,
-                                bgcolor: isDeleted ? 'error.50' : 'background.paper',
-                                opacity: isDeleted ? 0.6 : 1,
-                              }}
-                            >
-                              <Stack direction="row" justifyContent="space-between" alignItems="center">
-                                <Typography 
-                                  variant="body2" 
-                                  sx={{ 
-                                    textDecoration: isDeleted ? 'line-through' : 'none',
-                                    color: isDeleted ? 'error.main' : 'text.primary'
-                                  }}
-                                >
-                                  {attachment.fileName}
-                                </Typography>
-                                <Box>
-                                  {isDeleted ? (
-                                    <Button
-                                      size="small"
-                                      color="primary"
-                                      onClick={() => handleExistingAttachmentRestore(attachment.postAttachmentId)}
-                                    >
-                                      복원
-                                    </Button>
-                                  ) : (
-                                    <Button
-                                      size="small"
-                                      color="error"
-                                      onClick={() => handleExistingAttachmentDelete(attachment.postAttachmentId)}
-                                    >
-                                      삭제
-                                    </Button>
-                                  )}
-                                </Box>
-                              </Stack>
-                            </Box>
-                          );
-                        })}
-                      </Stack>
-                    </Box>
-                  )}
-
-                  {/* 새로운 파일 추가 섹션 */}
-                  <FileUploadSection
-                    files={newFiles}
-                    onSelect={handleFileSelect}
-                    onDelete={handleFileDelete}
-                    onRetry={handleFileRetry}
-                    onPreview={handleFilePreviewOpen}
-                  />
-                </Box>
+                <FileUploadSection
+                  files={newFiles}
+                  existingAttachments={detail.postAttachments || []}
+                  deletedAttachmentIds={deletedAttachmentIds}
+                  onSelect={handleFileSelect}
+                  onDelete={handleFileDelete}
+                  onRetry={handleFileRetry}
+                  onPreview={handleFilePreviewOpen}
+                  onExistingDelete={handleExistingAttachmentDelete}
+                  onExistingRestore={handleExistingAttachmentRestore}
+                  title="파일 수정"
+                  isEditing={true}
+                />
 
                 <Stack direction="row" justifyContent="flex-end" spacing={2}>
                   <Button variant="outlined" onClick={handleCancelEdit}>

--- a/src/hooks/useCompanyImageUpload.js
+++ b/src/hooks/useCompanyImageUpload.js
@@ -25,28 +25,23 @@ export default function useCompanyImageUpload() {
    * - 실제 업로드는 외부에서 별도 처리
    * 
    * @param {Event} event - 파일 선택 이벤트
+   * @returns {boolean} 검증 성공 여부
    */
   const handleImageSelect = async (event) => {
     const file = event.target.files[0];
-    if (!file) return;
+    if (!file) return false;
 
     // 파일 검증
     const errors = validateFile(file);
     if (errors.length > 0) {
       setError(errors.join(", "));
-      return;
+      return false;
     }
 
     // 이미지 파일인지 확인
     if (!file.type.startsWith("image/")) {
       setError("이미지 파일만 업로드 가능합니다.");
-      return;
-    }
-
-    // 파일 크기 제한 (5MB)
-    if (file.size > 5 * 1024 * 1024) {
-      setError("파일 크기는 5MB 이하여야 합니다.");
-      return;
+      return false;
     }
 
     setError(null);
@@ -56,6 +51,8 @@ export default function useCompanyImageUpload() {
     // 미리보기 URL 생성
     const url = URL.createObjectURL(file);
     setPreviewUrl(url);
+    
+    return true;
   };
 
   /**

--- a/src/hooks/usePostForm.js
+++ b/src/hooks/usePostForm.js
@@ -66,6 +66,21 @@ export default function usePostForm({ dispatch, open }) {
 
     if (newFiles.length === 0) return;
 
+    // 최대 첨부파일 개수 체크 (3개 제한)
+    const currentFileCount = files.length;
+    const maxFiles = 3;
+    const availableSlots = maxFiles - currentFileCount;
+
+    if (availableSlots <= 0) {
+      alert(`첨부파일은 최대 ${maxFiles}개까지만 등록할 수 있습니다.`);
+      return;
+    }
+
+    if (newFiles.length > availableSlots) {
+      alert(`첨부파일은 최대 ${maxFiles}개까지만 등록할 수 있습니다. (현재 ${currentFileCount}개, ${availableSlots}개 더 추가 가능)`);
+      return;
+    }
+
     const newFileItems = convertToFileItems(newFiles);
     setFiles((prev) => [...prev, ...newFileItems]);
 

--- a/src/utils/downloadUtils.js
+++ b/src/utils/downloadUtils.js
@@ -1,10 +1,12 @@
 export async function downloadAttachment(attachment, getPresignedUrlFn) {
   try {
+    // 1. GET /api/posts/attachment/download-url - 다운로드 URL 발급
     const response = await getPresignedUrlFn(attachment.id);
 
     if (response.data.result === "SUCCESS") {
       const downloadUrl = response.data.data.downloadUrl;
 
+      // 2. GET {downloadUrl} - 실제 파일 다운로드
       const fileResponse = await fetch(downloadUrl);
       if (!fileResponse.ok) throw new Error("파일 다운로드 실패");
 

--- a/src/utils/validateFile.js
+++ b/src/utils/validateFile.js
@@ -1,4 +1,5 @@
 // utils/validateFile.js
+import { formatFileSize } from "./formatFileSize";
 
 const DANGEROUS_EXTENSIONS = [
   ".exe",


### PR DESCRIPTION
## 📌 개요
- 게시글 수정시 이미지 업로드 기능 추가 및 작은 개선

## 🛠️ 변경 사항
- 게시글 수정시 이미지 업로드 기능 추가
- 게시글 생성/수정 페이지에서 파일 업로드 개수 최대 3개 제한 기능 추가
- 게시글 조회시 파일 바로 다운로드하는 로직 제거, 다운로드 버튼 클릭해야 다운로드하게 변경

## ✅ 주요 체크 포인트

## 🔁 테스트 결과


## 🔗 연관된 이슈
- #457 
## 연관된 PR
- https://github.com/Kernel360/KDEV5-MY-WORK-FE/pull/462
